### PR TITLE
Add asynchronous before hook

### DIFF
--- a/NSpec/nspec.cs
+++ b/NSpec/nspec.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq.Expressions;
 using NSpec.Domain;
+using System.Threading.Tasks;
 
 namespace NSpec
 {
@@ -53,6 +54,12 @@ namespace NSpec
         {
             get { return Context.Before; }
             set { Context.Before = value; }
+        }
+
+        public virtual Func<Task> asyncBefore
+        {
+            get { return Context.AsyncBefore; }
+            set { Context.AsyncBefore = value; }
         }
 
         /// <summary>

--- a/NSpecSpecs/NSpecSpecs.csproj
+++ b/NSpecSpecs/NSpecSpecs.csproj
@@ -76,6 +76,7 @@
     <Compile Include="describe_cecil.cs" />
     <Compile Include="describe_Conventions.cs" />
     <Compile Include="describe_output.cs" />
+    <Compile Include="describe_RunningSpecs\describe_async_before.cs" />
     <Compile Include="describe_RunningSpecs\describe_skipped_before_alls_when_excluded_by_tag.cs" />
     <Compile Include="describe_RunningSpecs\describe_before_and_after\abstract_class.cs" />
     <Compile Include="describe_RunningSpecs\describe_before_and_after\nested_contexts.cs" />

--- a/NSpecSpecs/describe_RunningSpecs/describe_async_before.cs
+++ b/NSpecSpecs/describe_RunningSpecs/describe_async_before.cs
@@ -1,0 +1,59 @@
+﻿using NSpec;
+using NSpec.Domain;
+using NSpecSpecs.WhenRunningSpecs;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NSpecSpecs.describe_RunningSpecs
+{
+    [TestFixture]
+    [Category("RunningSpecs")]
+    [Category("Async")]
+    public class describe_async_before : when_running_specs
+    {
+        class SpecClass : nspec
+        {
+            int state = 0;
+
+            void given_async_before_is_set()
+            {
+                asyncBefore = async () =>
+                {
+                    state = -1;
+
+                    await RunActionAsync(() => state = 1);
+                };
+
+                it["Should wait for its task to complete"] = () => 
+                    state.should_be(1);
+            }
+
+            async Task RunActionAsync(Action action)
+            {
+                Task fictiousAsyncOperation = Task.Run(action);
+
+                await fictiousAsyncOperation;
+            }
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            Run(typeof(SpecClass));
+        }
+
+        [Test]
+        public void async_before_waits_for_task_to_complete()
+        {
+            Example example = TheExample("Should wait for its task to complete");
+
+            example.HasRun.should_be_true();
+
+            example.Exception.should_be_null();
+        }
+    }
+}


### PR DESCRIPTION
Implementation adds the least amount of async code inside framework, by
offloading asynchronous client work to another thread. Only Context and
Extensions are affected.

Actual implementation has yet to be decided: this is reflected by the
two #defines: OFFLOAD_IN_SAFE_INVOKE, OFFLOAD_IN_CONTEXT.