### PR TITLE
Feature/expect async

### DIFF
--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception.cs
@@ -40,7 +40,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [TestFixture]
     [Category("RunningSpecs")]
     [Category("Async")]
-    public class describe_async_expected_exception : when_expecting_exception
+    public class describe_async_expected_exception_before_awaiting_a_task : when_expecting_exception
     {
         private class SpecClass : nspec
         {
@@ -48,23 +48,70 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             {
                 before = () => { };
 
-                itAsync["throws expected exception"] = expectAsync<InvalidOperationException>(async () => 
-                    await Task.Run(() => 
-                    { 
-                        throw new InvalidOperationException(); 
+                itAsync["throws expected exception"] = expectAsync<InvalidOperationException>(async () =>
+                    await Task.Run(() =>
+                    {
+                        throw new InvalidOperationException();
                     }));
 
-                itAsync["throws expected exception with expected error message"] = expectAsync<InvalidOperationException>("Testing", async () => 
+                itAsync["throws expected exception with expected error message"] = expectAsync<InvalidOperationException>("Testing", async () =>
                     await Task.Run(() => { throw new InvalidOperationException("Testing"); }));
 
-                itAsync["fails if expected exception does not throw"] = expectAsync<InvalidOperationException>(async () => 
+                itAsync["fails if expected exception does not throw"] = expectAsync<InvalidOperationException>(async () =>
                     await Task.Run(() => { }));
 
-                itAsync["fails if wrong exception thrown"] = expectAsync<InvalidOperationException>(async () => 
+                itAsync["fails if wrong exception thrown"] = expectAsync<InvalidOperationException>(async () =>
                     await Task.Run(() => { throw new ArgumentException(); }));
 
-                itAsync["fails if wrong error message is returned"] = expectAsync<InvalidOperationException>("Testing", async () => 
+                itAsync["fails if wrong error message is returned"] = expectAsync<InvalidOperationException>("Testing", async () =>
                     await Task.Run(() => { throw new InvalidOperationException("Blah"); }));
+            }
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            Run(typeof(SpecClass));
+        }
+    }
+
+    [TestFixture]
+    [Category("RunningSpecs")]
+    [Category("Async")]
+    public class describe_async_expected_exception_after_awaiting_a_task : when_expecting_exception
+    {
+        private class SpecClass : nspec
+        {
+            void method_level_context()
+            {
+                before = () => { };
+
+                itAsync["throws expected exception"] = expectAsync<InvalidOperationException>(async () => {
+                    await Task.Run(() => { });
+
+					throw new InvalidOperationException();
+                });
+
+                itAsync["throws expected exception with expected error message"] = expectAsync<InvalidOperationException>("Testing", async () => {
+                    await Task.Run(() => { } );
+
+					throw new InvalidOperationException("Testing");
+				});
+
+                itAsync["fails if expected exception does not throw"] = expectAsync<InvalidOperationException>(async () =>
+                    await Task.Run(() => { }));
+
+                itAsync["fails if wrong exception thrown"] = expectAsync<InvalidOperationException>(async () => {
+                    await Task.Run(() => { } );
+
+					throw new ArgumentException();
+				});
+
+                itAsync["fails if wrong error message is returned"] = expectAsync<InvalidOperationException>("Testing", async () => {
+                    await Task.Run(() => {  } );
+
+					throw new InvalidOperationException("Blah");
+				});
             }
         }
 

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception_in_act.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception_in_act.cs
@@ -43,7 +43,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [TestFixture]
     [Category("RunningSpecs")]
     [Category("Async")]
-    public class describe_expected_exception_in_async_act : when_expecting_exception_in_act
+    public class describe_expected_exception_in_async_act_before_awaiting_a_task : when_expecting_exception_in_act
     {
         private class SpecClass : nspec
         {
@@ -73,10 +73,49 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         }
     }
 
+    [TestFixture]
+    [Category("RunningSpecs")]
+    [Category("Async")]
+    public class describe_expected_exception_in_async_act_after_awaiting_a_task : when_expecting_exception_in_act
+    {
+        private class SpecClass : nspec
+        {
+            void method_level_context()
+            {
+                it["fails if no exception thrown"] = expect<InvalidOperationException>();
+
+				context["when exception thrown from act after awaiting another task"] = () =>
+				{
+					long count = 0;
+					actAsync = async () =>
+					{
+						await Task.Run(() => count++ );
+
+						throw new InvalidOperationException("Testing");
+					};
+
+                    it["threw the expected exception in act"] = expect<InvalidOperationException>();
+
+                    it["threw the exception in act with expected error message"] = expect<InvalidOperationException>("Testing");
+
+                    it["fails if wrong exception thrown"] = expect<ArgumentException>();
+
+                    it["fails if wrong error message is returned"] = expect<InvalidOperationException>("Blah");
+                };
+            }
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            Run(typeof(SpecClass));
+        }
+    }
+
     public abstract class when_expecting_exception_in_act : when_running_specs
     {
         [Test]
-        public void should_be_two_failures()
+        public void should_be_three_failures()
         {
             classContext.Failures().Count().should_be(3);
         }
@@ -112,7 +151,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         public void fails_if_wrong_error_message_is_returned()
         {
             var exception = TheExample("fails if wrong error message is returned").Exception;
-            
+
             exception.GetType().should_be(typeof(ExceptionNotThrown));
             exception.Message.should_be("Expected message: \"Blah\" But was: \"Testing\"");
         }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception_in_act.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception_in_act.cs
@@ -86,10 +86,9 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 
 				context["when exception thrown from act after awaiting another task"] = () =>
 				{
-					long count = 0;
 					actAsync = async () =>
 					{
-						await Task.Run(() => count++ );
+						await Task.Run(() => { } );
 
 						throw new InvalidOperationException("Testing");
 					};
@@ -127,17 +126,13 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 				{
 					actAsync = () =>
 					{
-						long count = 0;
 						var tasks = Enumerable.Range(0, 10)
-							.Select(
-								e => Task.Run(
-									() =>
-									{
-										if (e == 4)
-										{
-											throw new InvalidOperationException("Testing");
-										}
-									}));
+							.Select(e => Task.Run(() => {
+								if (e == 4)
+								{
+									throw new InvalidOperationException("Testing");
+								}
+							}));
 
 						return Task.WhenAll(tasks);
 					};

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception_in_act.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception_in_act.cs
@@ -53,7 +53,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 
                 context["when exception thrown from act"] = () =>
                 {
-                    actAsync = async () => await Task.Run(() => { throw new InvalidOperationException("Testing"); });
+                    actAsync = () => Task.Run(() => { throw new InvalidOperationException("Testing"); });
 
                     it["threw the expected exception in act"] = expect<InvalidOperationException>();
 
@@ -92,6 +92,54 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 						await Task.Run(() => count++ );
 
 						throw new InvalidOperationException("Testing");
+					};
+
+                    it["threw the expected exception in act"] = expect<InvalidOperationException>();
+
+                    it["threw the exception in act with expected error message"] = expect<InvalidOperationException>("Testing");
+
+                    it["fails if wrong exception thrown"] = expect<ArgumentException>();
+
+                    it["fails if wrong error message is returned"] = expect<InvalidOperationException>("Blah");
+                };
+            }
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            Run(typeof(SpecClass));
+        }
+    }
+
+    [TestFixture]
+    [Category("RunningSpecs")]
+    [Category("Async")]
+    public class describe_expected_exception_in_async_act_within_list_of_tasks : when_expecting_exception_in_act
+    {
+        private class SpecClass : nspec
+        {
+            void method_level_context()
+            {
+                it["fails if no exception thrown"] = expect<InvalidOperationException>();
+
+				context["when exception thrown from act within a list of tasks"] = () =>
+				{
+					actAsync = () =>
+					{
+						long count = 0;
+						var tasks = Enumerable.Range(0, 10)
+							.Select(
+								e => Task.Run(
+									() =>
+									{
+										if (e == 4)
+										{
+											throw new InvalidOperationException("Testing");
+										}
+									}));
+
+						return Task.WhenAll(tasks);
 					};
 
                     it["threw the expected exception in act"] = expect<InvalidOperationException>();


### PR DESCRIPTION
Updated `expect` so that exceptions are handled within asynchronous processes (ie: `async` / `await`) and the `AggregateException` is examined for the expected exception type. The original discussion can be found [here](https://github.com/mattflo/NSpec/issues/83#issuecomment-125224912). Also removed some trailing whitespace.