### PR TITLE
Test exception custom types

### DIFF
--- a/NSpecSpecs/NSpecSpecs.csproj
+++ b/NSpecSpecs/NSpecSpecs.csproj
@@ -125,6 +125,7 @@
     <Compile Include="describe_RunningSpecs\describe_todo.cs" />
     <Compile Include="describe_ContextCollection.cs" />
     <Compile Include="describe_DefaultConventions.cs" />
+    <Compile Include="describe_RunningSpecs\Exceptions\TestFixtureExceptions.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_act_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_after_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_before_contains_exception.cs" />

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/TestFixtureExceptions.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/TestFixtureExceptions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NSpecSpecs.describe_RunningSpecs.Exceptions
+{
+    class KnownException : Exception
+    {
+        public KnownException() : base() { }
+        public KnownException(string message) : base(message) { }
+    }
+
+    class SomeOtherException : Exception
+    {
+        public SomeOtherException() : base() { }
+    }
+}

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/TestFixtureExceptions.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/TestFixtureExceptions.cs
@@ -6,6 +6,51 @@ using System.Threading.Tasks;
 
 namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 {
+    class BeforeAllException : Exception
+    {
+        public BeforeAllException() : base("BeforeAllException") { }
+    }
+
+    class BeforeException : Exception
+    {
+        public BeforeException() : base("BeforeException") { }
+    }
+
+    class NestedBeforeException : Exception
+    {
+        public NestedBeforeException() : base("NestedBeforeException") { }
+    }
+
+    class ActException : Exception
+    {
+        public ActException() : base("ActException") { }
+    }
+
+    class NestedActException : Exception
+    {
+        public NestedActException() : base("NestedActException") { }
+    }
+
+    class ItException : Exception
+    {
+        public ItException() : base("ItException") { }
+    }
+
+    class AfterException : Exception
+    {
+        public AfterException() : base("AfterException") { }
+    }
+
+    class NestedAfterException : Exception
+    {
+        public NestedAfterException() : base("NestedAfterException") { }
+    }
+
+    class AfterAllException : Exception
+    {
+        public AfterAllException() : base("AfterAllException") { }
+    }
+
     class KnownException : Exception
     {
         public KnownException() : base() { }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception.cs
@@ -18,15 +18,15 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             {
                 before = () => { };
 
-                it["throws expected exception"] = expect<InvalidOperationException>(() => { throw new InvalidOperationException(); });
+                it["throws expected exception"] = expect<KnownException>(() => { throw new KnownException(); });
 
-                it["throws expected exception with expected error message"] = expect<InvalidOperationException>("Testing", () => { throw new InvalidOperationException("Testing"); });
+                it["throws expected exception with expected error message"] = expect<KnownException>("Testing", () => { throw new KnownException("Testing"); });
 
-                it["fails if expected exception does not throw"] = expect<InvalidOperationException>(() => { });
+                it["fails if expected exception does not throw"] = expect<KnownException>(() => { });
 
-                it["fails if wrong exception thrown"] = expect<InvalidOperationException>(() => { throw new ArgumentException(); });
+                it["fails if wrong exception thrown"] = expect<KnownException>(() => { throw new SomeOtherException(); });
 
-                it["fails if wrong error message is returned"] = expect<InvalidOperationException>("Testing", () => { throw new InvalidOperationException("Blah"); });
+                it["fails if wrong error message is returned"] = expect<KnownException>("Testing", () => { throw new KnownException("Blah"); });
             }
         }
 
@@ -48,23 +48,23 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             {
                 before = () => { };
 
-                itAsync["throws expected exception"] = expectAsync<InvalidOperationException>(async () =>
+                itAsync["throws expected exception"] = expectAsync<KnownException>(async () =>
                     await Task.Run(() =>
                     {
-                        throw new InvalidOperationException();
+                        throw new KnownException();
                     }));
 
-                itAsync["throws expected exception with expected error message"] = expectAsync<InvalidOperationException>("Testing", async () =>
-                    await Task.Run(() => { throw new InvalidOperationException("Testing"); }));
+                itAsync["throws expected exception with expected error message"] = expectAsync<KnownException>("Testing", async () =>
+                    await Task.Run(() => { throw new KnownException("Testing"); }));
 
-                itAsync["fails if expected exception does not throw"] = expectAsync<InvalidOperationException>(async () =>
+                itAsync["fails if expected exception does not throw"] = expectAsync<KnownException>(async () =>
                     await Task.Run(() => { }));
 
-                itAsync["fails if wrong exception thrown"] = expectAsync<InvalidOperationException>(async () =>
-                    await Task.Run(() => { throw new ArgumentException(); }));
+                itAsync["fails if wrong exception thrown"] = expectAsync<KnownException>(async () =>
+                    await Task.Run(() => { throw new SomeOtherException(); }));
 
-                itAsync["fails if wrong error message is returned"] = expectAsync<InvalidOperationException>("Testing", async () =>
-                    await Task.Run(() => { throw new InvalidOperationException("Blah"); }));
+                itAsync["fails if wrong error message is returned"] = expectAsync<KnownException>("Testing", async () =>
+                    await Task.Run(() => { throw new KnownException("Blah"); }));
             }
         }
 
@@ -86,31 +86,31 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             {
                 before = () => { };
 
-                itAsync["throws expected exception"] = expectAsync<InvalidOperationException>(async () => {
+                itAsync["throws expected exception"] = expectAsync<KnownException>(async () => {
                     await Task.Run(() => { });
 
-                    throw new InvalidOperationException();
+                    throw new KnownException();
                 });
 
-                itAsync["throws expected exception with expected error message"] = expectAsync<InvalidOperationException>("Testing", async () => {
+                itAsync["throws expected exception with expected error message"] = expectAsync<KnownException>("Testing", async () => {
                     await Task.Run(() => { } );
 
-                    throw new InvalidOperationException("Testing");
+                    throw new KnownException("Testing");
                 });
 
-                itAsync["fails if expected exception does not throw"] = expectAsync<InvalidOperationException>(async () =>
+                itAsync["fails if expected exception does not throw"] = expectAsync<KnownException>(async () =>
                     await Task.Run(() => { }));
 
-                itAsync["fails if wrong exception thrown"] = expectAsync<InvalidOperationException>(async () => {
+                itAsync["fails if wrong exception thrown"] = expectAsync<KnownException>(async () => {
                     await Task.Run(() => { } );
 
-                    throw new ArgumentException();
+                    throw new SomeOtherException();
                 });
 
-                itAsync["fails if wrong error message is returned"] = expectAsync<InvalidOperationException>("Testing", async () => {
+                itAsync["fails if wrong error message is returned"] = expectAsync<KnownException>("Testing", async () => {
                     await Task.Run(() => {  } );
 
-                    throw new InvalidOperationException("Blah");
+                    throw new KnownException("Blah");
                 });
             }
         }
@@ -154,7 +154,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             var exception = TheExample("fails if wrong exception thrown").Exception;
 
             exception.GetType().should_be(typeof(ExceptionNotThrown));
-            exception.Message.should_be("Exception of type InvalidOperationException was not thrown.");
+            exception.Message.should_be("Exception of type KnownException was not thrown.");
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception_in_act.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_expected_exception_in_act.cs
@@ -16,19 +16,19 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             void method_level_context()
             {
-                it["fails if no exception thrown"] = expect<InvalidOperationException>();
+                it["fails if no exception thrown"] = expect<KnownException>();
 
                 context["when exception thrown from act"] = () =>
                 {
-                    act = () => { throw new InvalidOperationException("Testing"); };
+                    act = () => { throw new KnownException("Testing"); };
 
-                    it["threw the expected exception in act"] = expect<InvalidOperationException>();
+                    it["threw the expected exception in act"] = expect<KnownException>();
 
-                    it["threw the exception in act with expected error message"] = expect<InvalidOperationException>("Testing");
+                    it["threw the exception in act with expected error message"] = expect<KnownException>("Testing");
 
-                    it["fails if wrong exception thrown"] = expect<ArgumentException>();
+                    it["fails if wrong exception thrown"] = expect<SomeOtherException>();
 
-                    it["fails if wrong error message is returned"] = expect<InvalidOperationException>("Blah");
+                    it["fails if wrong error message is returned"] = expect<KnownException>("Blah");
                 };
             }
         }
@@ -49,19 +49,19 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             void method_level_context()
             {
-                it["fails if no exception thrown"] = expect<InvalidOperationException>();
+                it["fails if no exception thrown"] = expect<KnownException>();
 
                 context["when exception thrown from act"] = () =>
                 {
-                    actAsync = () => Task.Run(() => { throw new InvalidOperationException("Testing"); });
+                    actAsync = () => Task.Run(() => { throw new KnownException("Testing"); });
 
-                    it["threw the expected exception in act"] = expect<InvalidOperationException>();
+                    it["threw the expected exception in act"] = expect<KnownException>();
 
-                    it["threw the exception in act with expected error message"] = expect<InvalidOperationException>("Testing");
+                    it["threw the exception in act with expected error message"] = expect<KnownException>("Testing");
 
-                    it["fails if wrong exception thrown"] = expect<ArgumentException>();
+                    it["fails if wrong exception thrown"] = expect<SomeOtherException>();
 
-                    it["fails if wrong error message is returned"] = expect<InvalidOperationException>("Blah");
+                    it["fails if wrong error message is returned"] = expect<KnownException>("Blah");
                 };
             }
         }
@@ -82,7 +82,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             void method_level_context()
             {
-                it["fails if no exception thrown"] = expect<InvalidOperationException>();
+                it["fails if no exception thrown"] = expect<KnownException>();
 
                 context["when exception thrown from act after awaiting another task"] = () =>
                 {
@@ -90,16 +90,16 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
                     {
                         await Task.Run(() => { } );
 
-                        throw new InvalidOperationException("Testing");
+                        throw new KnownException("Testing");
                     };
 
-                    it["threw the expected exception in act"] = expect<InvalidOperationException>();
+                    it["threw the expected exception in act"] = expect<KnownException>();
 
-                    it["threw the exception in act with expected error message"] = expect<InvalidOperationException>("Testing");
+                    it["threw the exception in act with expected error message"] = expect<KnownException>("Testing");
 
-                    it["fails if wrong exception thrown"] = expect<ArgumentException>();
+                    it["fails if wrong exception thrown"] = expect<SomeOtherException>();
 
-                    it["fails if wrong error message is returned"] = expect<InvalidOperationException>("Blah");
+                    it["fails if wrong error message is returned"] = expect<KnownException>("Blah");
                 };
             }
         }
@@ -120,7 +120,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             void method_level_context()
             {
-                it["fails if no exception thrown"] = expect<InvalidOperationException>();
+                it["fails if no exception thrown"] = expect<KnownException>();
 
                 context["when exception thrown from act within a list of tasks"] = () =>
                 {
@@ -130,20 +130,20 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
                             .Select(e => Task.Run(() => {
                                 if (e == 4)
                                 {
-                                    throw new InvalidOperationException("Testing");
+                                    throw new KnownException("Testing");
                                 }
                             }));
 
                         return Task.WhenAll(tasks);
                     };
 
-                    it["threw the expected exception in act"] = expect<InvalidOperationException>();
+                    it["threw the expected exception in act"] = expect<KnownException>();
 
-                    it["threw the exception in act with expected error message"] = expect<InvalidOperationException>("Testing");
+                    it["threw the exception in act with expected error message"] = expect<KnownException>("Testing");
 
-                    it["fails if wrong exception thrown"] = expect<ArgumentException>();
+                    it["fails if wrong exception thrown"] = expect<SomeOtherException>();
 
-                    it["fails if wrong error message is returned"] = expect<InvalidOperationException>("Blah");
+                    it["fails if wrong error message is returned"] = expect<KnownException>("Blah");
                 };
             }
         }
@@ -187,7 +187,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             var exception = TheExample("fails if wrong exception thrown").Exception;
 
             exception.GetType().should_be(typeof(ExceptionNotThrown));
-            exception.Message.should_be("Exception of type ArgumentException was not thrown.");
+            exception.Message.should_be("Exception of type SomeOtherException was not thrown.");
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_unexpected_exception_in_act.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/describe_unexpected_exception_in_act.cs
@@ -17,12 +17,12 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
                 {
                     act = () => 
                     { 
-                        throw new InvalidOperationException("unexpected failure"); 
+                        throw new KnownException("unexpected failure"); 
                     };
 
                     it["reports example level failure and act failure"] = () => 
                     {
-                        throw new InvalidOperationException("example level failure");
+                        throw new KnownException("example level failure");
                     };
                 };
             }
@@ -53,7 +53,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
                 {
                     act = () =>
                     {
-                        throw new InvalidOperationException("unexpected failure");
+                        throw new KnownException("unexpected failure");
                     };
 
                     it["reports example level failure and act failure"] = () =>
@@ -88,12 +88,12 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
                 {
                     actAsync = async () => await Task.Run(() =>
                     {
-                        throw new InvalidOperationException("unexpected failure");
+                        throw new KnownException("unexpected failure");
                     });
 
                     itAsync["reports example level failure and act failure"] = async () => await Task.Run(() =>
                     {
-                        throw new InvalidOperationException("example level failure");
+                        throw new KnownException("example level failure");
                     });
                 };
             }
@@ -124,7 +124,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
                 {
                     actAsync = async () => await Task.Run(() =>
                     {
-                        throw new InvalidOperationException("unexpected failure");
+                        throw new KnownException("unexpected failure");
                     });
 
                     itAsync["reports example level failure and act failure"] = async () =>

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_act_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_act_contains_exception.cs
@@ -14,7 +14,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             void method_level_context()
             {
-                act = () => { throw new InvalidOperationException(); };
+                act = () => { throw new ActException(); };
 
                 it["should fail this example because of act"] = () => "1".should_be("1");
 
@@ -41,9 +41,9 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         public void it_should_fail_all_examples_in_act()
         {
             TheExample("should fail this example because of act").Exception
-                .InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .InnerException.GetType().should_be(typeof(ActException));
             TheExample("should also fail this example because of act").Exception
-                .InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .InnerException.GetType().should_be(typeof(ActException));
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_after_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_after_contains_exception.cs
@@ -14,7 +14,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             void method_level_context()
             {
-                after = () => { throw new InvalidOperationException(); };
+                after = () => { throw new AfterException(); };
 
                 it["should fail this example because of after"] = () => "1".should_be("1");
 
@@ -22,7 +22,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 
                 context["exception thrown by both act and after"] = () =>
                 {
-                    act = () => { throw new ArgumentException("The after's exception should not overwrite the act's exception"); };
+                    act = () => { throw new ActException(); };
 
                     it["tracks only the first exception from act"] = () => "1".should_be("1");
                 };
@@ -50,16 +50,16 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         public void examples_with_only_after_failure_should_only_fail_because_of_after()
         {
             TheExample("should fail this example because of after")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(AfterException));
             TheExample("should also fail this example because of after")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(AfterException));
         }
 
         [Test]
         public void it_should_throw_exception_from_act_not_from_after()
         {
             TheExample("tracks only the first exception from act")
-                .Exception.InnerException.GetType().should_be(typeof(ArgumentException));
+                .Exception.InnerException.GetType().should_be(typeof(ActException));
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_act_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_act_contains_exception.cs
@@ -16,7 +16,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             void method_level_context()
             {
-                actAsync = async () => await Task.Run(() => { throw new InvalidOperationException(); });
+                actAsync = async () => await Task.Run(() => { throw new ActException(); });
 
                 it["should fail this example because of act"] = () => "1".should_be("1");
 
@@ -43,9 +43,9 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         public void it_should_fail_all_examples_in_act()
         {
             TheExample("should fail this example because of act").Exception
-                .InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .InnerException.GetType().should_be(typeof(ActException));
             TheExample("should also fail this example because of act").Exception
-                .InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .InnerException.GetType().should_be(typeof(ActException));
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_after_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_after_contains_exception.cs
@@ -19,7 +19,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
                 afterAsync = async () =>
                 {
                     await Task.Delay(0);
-                    throw new InvalidOperationException(); 
+                    throw new AfterException(); 
                 };
 
                 it["should fail this example because of afterAsync"] = () => "1".should_be("1");
@@ -28,7 +28,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 
                 context["exception thrown by both act and afterAsync"] = () =>
                 {
-                    act = () => { throw new ArgumentException("The afterAsync's exception should not overwrite the act's exception"); };
+                    act = () => { throw new ActException(); };
 
                     it["tracks only the first exception from act"] = () => "1".should_be("1");
                 };
@@ -56,16 +56,16 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         public void examples_with_only_async_after_failure_should_only_fail_because_of_after()
         {
             TheExample("should fail this example because of afterAsync")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(AfterException));
             TheExample("should also fail this example because of afterAsync")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(AfterException));
         }
 
         [Test]
         public void it_should_throw_exception_from_act_not_from_async_after()
         {
             TheExample("tracks only the first exception from act")
-                .Exception.InnerException.GetType().should_be(typeof(ArgumentException));
+                .Exception.InnerException.GetType().should_be(typeof(ActException));
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_before_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_before_contains_exception.cs
@@ -19,7 +19,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
                 beforeAsync = async () => 
                 { 
                     await Task.Delay(0);
-                    throw new InvalidOperationException(); 
+                    throw new BeforeException(); 
                 };
 
                 it["should fail this example because of beforeAsync"] = () => "1".should_be("1");
@@ -28,7 +28,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 
                 context["exception thrown by both beforeAsync and act"] = () =>
                 {
-                    act = () => { throw new ArgumentException("this exception should never be thrown"); };
+                    act = () => { throw new ActException(); };
 
                     it["tracks only the first exception from 'beforeAsync'"] = () => "1".should_be("1");
                 };
@@ -56,16 +56,16 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         public void it_should_fail_all_examples_in_async_before()
         {
             TheExample("should fail this example because of beforeAsync")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(BeforeException));
             TheExample("should also fail this example because of beforeAsync")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(BeforeException));
         }
 
         [Test]
         public void it_should_throw_exception_from_async_before_not_from_act()
         {
             TheExample("tracks only the first exception from 'beforeAsync'")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(BeforeException));
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_method_level_before_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_method_level_before_contains_exception.cs
@@ -19,7 +19,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             {
                 await Task.Delay(0);
 
-                throw new InvalidOperationException();
+                throw new BeforeException();
             }
 
             void should_fail_this_example()

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_before_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_before_contains_exception.cs
@@ -14,7 +14,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             void method_level_context()
             {
-                before = () => { throw new InvalidOperationException(); };
+                before = () => { throw new BeforeException(); };
 
                 it["should fail this example because of before"] = () => "1".should_be("1");
 
@@ -22,7 +22,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 
                 context["exception thrown by both before and act"] = () =>
                 {
-                    act = () => { throw new ArgumentException("this exception should never be thrown"); };
+                    act = () => { throw new ActException(); };
 
                     it["tracks only the first exception from 'before'"] = () => "1".should_be("1");
                 };
@@ -50,16 +50,16 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         public void it_should_fail_all_examples_in_before()
         {
             TheExample("should fail this example because of before")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(BeforeException));
             TheExample("should also fail this example because of before")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(BeforeException));
         }
 
         [Test]
         public void it_should_throw_exception_from_before_not_from_act()
         {
             TheExample("tracks only the first exception from 'before'")
-                .Exception.InnerException.GetType().should_be(typeof(InvalidOperationException));
+                .Exception.InnerException.GetType().should_be(typeof(BeforeException));
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_before_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_before_contains_exception.cs
@@ -15,7 +15,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             void before_each()
             {
-                throw new InvalidOperationException();
+                throw new BeforeException();
             }
 
             void should_fail_this_example()


### PR DESCRIPTION
While working on extending async, and also on exception detection in beforeAll/ afterAll, many times we found it hard to reason about failing tests or creating new tests because the dummy exception they threw were not related at all with the actual testcase.

E.g. sometimes an `InvalidOperationException` was expected from `act`, and other times it was expected from another hook. 

We found it much easier if tests threw well-named exception types, that were easily recognisable and easily associated to a specific nspec hook.  
With such custom types, most of the times there was no need anymore for specific exception messages: the type was enough, and an implicit message passed in constructor made everything clear in debug Locals window too.