### PR TITLE
Remove ContextBuilder dependency from ContextRunner ...

### DIFF
--- a/NSpec/Domain/ContextBuilder.cs
+++ b/NSpec/Domain/ContextBuilder.cs
@@ -131,7 +131,7 @@ namespace NSpec.Domain
             this.tagsFilter = tagsFilter;
         }
 
-        public Tags tagsFilter;
+        Tags tagsFilter;
 
         Conventions conventions;
 

--- a/NSpec/Domain/ContextRunner.cs
+++ b/NSpec/Domain/ContextRunner.cs
@@ -16,7 +16,7 @@ namespace NSpec.Domain
 
                 contexts.Run(liveFormatter, failFast);
 
-                if (builder.tagsFilter.HasTagFilters()) contexts.TrimSkippedContexts();
+                if (tagsFilter.HasTagFilters()) contexts.TrimSkippedContexts();
 
                 formatter.Write(contexts);
             }
@@ -28,14 +28,14 @@ namespace NSpec.Domain
             return contexts;
         }
 
-        public ContextRunner(ContextBuilder builder, IFormatter formatter, bool failFast)
+        public ContextRunner(Tags tagsFilter, IFormatter formatter, bool failFast)
         {
             this.failFast = failFast;
-            this.builder = builder;
+            this.tagsFilter = tagsFilter;
             this.formatter = formatter;
         }
 
-        ContextBuilder builder;
+        Tags tagsFilter;
         bool failFast;
         IFormatter formatter;
     }

--- a/NSpec/Domain/RunnerInvocation.cs
+++ b/NSpec/Domain/RunnerInvocation.cs
@@ -12,17 +12,21 @@ namespace NSpec.Domain
 
             var finder = new SpecFinder(reflector);
 
-            var builder = new ContextBuilder(finder, new Tags().Parse(Tags), new DefaultConventions());
+            var tagsFilter = new Tags().Parse(Tags);
 
-            var runner = new ContextRunner(builder, Formatter, failFast);
+            var builder = new ContextBuilder(finder, tagsFilter, new DefaultConventions());
+
+            var runner = new ContextRunner(tagsFilter, Formatter, failFast);
 
             var contexts = builder.Contexts().Build();
 
             if(contexts.AnyTaggedWithFocus())
             {
-                builder = new ContextBuilder(finder, new Tags().Parse(NSpec.Domain.Tags.Focus), new DefaultConventions());
+                tagsFilter = new Tags().Parse(NSpec.Domain.Tags.Focus);
 
-                runner = new ContextRunner(builder, Formatter, failFast);
+                builder = new ContextBuilder(finder, tagsFilter, new DefaultConventions());
+
+                runner = new ContextRunner(tagsFilter, Formatter, failFast);
 
                 contexts = builder.Contexts().Build();
             }

--- a/NSpecSpecs/ClassContextBug/NestContextsTests.cs
+++ b/NSpecSpecs/ClassContextBug/NestContextsTests.cs
@@ -23,8 +23,9 @@ namespace NSpecSpecs.ClassContextBug
             var builder = new ContextBuilder(finder, new DefaultConventions());
 
             //this line runs the tests you specified in the filter
+            var noTagsFilter = new Tags();
             TestFormatter formatter = new TestFormatter();
-            new ContextRunner(builder, formatter, false).Run(builder.Contexts().Build());
+            new ContextRunner(noTagsFilter, formatter, false).Run(builder.Contexts().Build());
 
             Context grandParent = formatter.Contexts[0];
             Assert.That(grandParent.Name, Is.EqualTo("Grand Parent"));

--- a/NSpecSpecs/DebuggerShim.cs
+++ b/NSpecSpecs/DebuggerShim.cs
@@ -31,9 +31,15 @@ public class DebuggerShim
         var types = GetType().Assembly.GetTypes(); 
         // OR
         // var types = new Type[]{typeof(Some_Type_Containg_some_Specs)};
+
         var finder = new SpecFinder(types, "");
-        var builder = new ContextBuilder(finder, new Tags().Parse(tagOrClassName), new DefaultConventions());
-        var runner = new ContextRunner(builder, new ConsoleFormatter(), false);
+
+        var tagsFilter = new Tags().Parse(tagOrClassName);
+
+        var builder = new ContextBuilder(finder, tagsFilter, new DefaultConventions());
+
+        var runner = new ContextRunner(tagsFilter, new ConsoleFormatter(), false);
+
         var results = runner.Run(builder.Contexts().Build());
 
         //assert that there aren't any failures

--- a/NSpecSpecs/describe_RunningSpecs/when_running_specs.cs
+++ b/NSpecSpecs/describe_RunningSpecs/when_running_specs.cs
@@ -23,9 +23,11 @@ namespace NSpecSpecs.WhenRunningSpecs
 
             this.types = types;
 
-            builder = new ContextBuilder(new SpecFinder(types), new Tags().Parse(tags), new DefaultConventions());
+            var tagsFilter = new Tags().Parse(tags);
 
-            runner = new ContextRunner(builder, formatter, failFast);
+            builder = new ContextBuilder(new SpecFinder(types), tagsFilter, new DefaultConventions());
+
+            runner = new ContextRunner(tagsFilter, formatter, failFast);
 
             contextCollection = builder.Contexts();
 

--- a/NSpecSpecs/describe_output.cs
+++ b/NSpecSpecs/describe_output.cs
@@ -76,13 +76,14 @@ namespace NSpecSpecs
         public void output_verification(Type output, Type []testClasses, string tags)
         {
             var finder = new SpecFinder(testClasses, "");
-            var builder = new ContextBuilder(finder, new Tags().Parse(tags), new DefaultConventions());
+            var tagsFilter = new Tags().Parse(tags);
+            var builder = new ContextBuilder(finder, tagsFilter, new DefaultConventions());
             var consoleFormatter = new ConsoleFormatter();
 
             var actual = new System.Collections.Generic.List<string>();
             consoleFormatter.WriteLineDelegate = actual.Add;
 
-            var runner = new ContextRunner(builder, consoleFormatter, false);
+            var runner = new ContextRunner(tagsFilter, consoleFormatter, false);
             runner.Run(builder.Contexts().Build());
 
             var expectedString = ScrubStackTrace(ScrubNewLines(output.GetField("Output").GetValue(null) as string));


### PR DESCRIPTION
... as that is just to pass `Tags` filter to the runner. 
But usually a `ContextRunner` creator already knows the `Tags` filter, so it might as well pass those directly to the *runner*, as it already does with the *builder*.