### PR TITLE
nspec output should respect Environment.NewLine

### DIFF
--- a/NSpec/Domain/Extensions/DomainExtensions.cs
+++ b/NSpec/Domain/Extensions/DomainExtensions.cs
@@ -67,7 +67,7 @@ namespace NSpec.Domain.Extensions
 
         public static string CleanMessage(this Exception exception)
         {
-            var exc = exception.Message.Trim().Replace("\n", ", ").Trim();
+            var exc = exception.Message.Trim().Replace("\r\n", ", ").Replace("\n", ", ").Trim();
 
             while (exc.Contains("  ")) exc = exc.Replace("  ", " ");
 


### PR DESCRIPTION
When running specifications with `NSpecRunner.exe` the console output should look like this

```
describe specifications
  when creating specifications
    true should be false - FAILED - Expected: False
, But was: True
```

but looks like

```
describe specifications
  when creating specifications
, But was: True be false - FAILED - Expected: False
```

the issue comes from the ` DomainExtensions.CleanMessage` extension method which converts `<crlf>` to `<lf>`: `exception.Message.Trim().Replace("\n", ", ").Trim();`