### PR TITLE
Update XUnitFormatter to write to file instead of Console

### DIFF
--- a/NSpec/Domain/Formatters/ConsoleFormatter.cs
+++ b/NSpec/Domain/Formatters/ConsoleFormatter.cs
@@ -23,6 +23,7 @@ namespace NSpec.Domain.Formatters
             Console.ResetColor();
         }
 
+        public IDictionary<string, string> Options { get; set; }
         public void Write(Context context)
         {
             if (context.Level == 1) WriteLineDelegate("");

--- a/NSpec/Domain/Formatters/HtmlFormatter.cs
+++ b/NSpec/Domain/Formatters/HtmlFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Web;
@@ -48,6 +49,8 @@ namespace NSpec.Domain.Formatters
 
             Console.WriteLine(sb.ToString());
         }
+
+        public IDictionary<string, string> Options { get; set; }
 
         void BuildParentContext(StringBuilder sb, Context context)
         {

--- a/NSpec/Domain/Formatters/IFormatters.cs
+++ b/NSpec/Domain/Formatters/IFormatters.cs
@@ -1,8 +1,13 @@
+using System;
+using System.Collections.Generic;
+
 namespace NSpec.Domain.Formatters
 {
     public interface IFormatter
     {
         void Write(ContextCollection contexts);
+
+        IDictionary<string, string> Options { get; set; }
     }
 
     public interface ILiveFormatter

--- a/NSpec/Domain/Formatters/SilentLiveFormatter.cs
+++ b/NSpec/Domain/Formatters/SilentLiveFormatter.cs
@@ -13,5 +13,7 @@ namespace NSpec.Domain.Formatters
         public void Write(ExampleBase example, int level) { }
 
         public void Write(ContextCollection contexts) { }
+
+        public IDictionary<string, string> Options { get; set; }
     }
 }

--- a/NSpec/Domain/Formatters/TiddlyWikiFormatter.cs
+++ b/NSpec/Domain/Formatters/TiddlyWikiFormatter.cs
@@ -31,6 +31,8 @@ namespace NSpec.Domain.Formatters
                                  examplesCount, failuresCount, pendingsCount);
         }
 
+        public IDictionary<string, string> Options { get; set; }
+
         void WriteTiddlyWiki(
             string menuItems, string tiddlerItems,
             int examplesCount, int failuresCount, int pendingCount)

--- a/NSpec/Domain/Formatters/XUnitFormatter.cs
+++ b/NSpec/Domain/Formatters/XUnitFormatter.cs
@@ -38,8 +38,10 @@ namespace NSpec.Domain.Formatters
             var filePath = Path.Combine(Environment.CurrentDirectory, this.file);
             using (StreamWriter ostream = new StreamWriter(filePath, false))
             {
-                ostream.WriteLine(sb.ToString());
-                Console.WriteLine($"Test results published to: {filePath}");
+                var results = sb.ToString();
+                ostream.WriteLine(results);
+                Console.WriteLine(results);
+                //Console.WriteLine($"Test results published to: {filePath}");
             }
             
                         

--- a/NSpec/Domain/Formatters/XUnitFormatter.cs
+++ b/NSpec/Domain/Formatters/XUnitFormatter.cs
@@ -9,12 +9,23 @@ namespace NSpec.Domain.Formatters
     [Serializable]
     public class XUnitFormatter : IFormatter
     {
+        string file;
+
+        public XUnitFormatter(string file)
+        {
+            this.file = file ?? "nspec-results.xml";
+        }
+
+        public XUnitFormatter():this(null)
+        {
+            
+        }
         public void Write(ContextCollection contexts)
         {
             StringBuilder sb = new StringBuilder();
             StringWriter sw = new StringWriter(sb);
             XmlTextWriter xml = new XmlTextWriter(sw);
-
+            
             xml.WriteStartElement("testsuites");
             xml.WriteAttributeString("tests", contexts.Examples().Count().ToString());
             xml.WriteAttributeString("errors", "0");
@@ -24,7 +35,15 @@ namespace NSpec.Domain.Formatters
             contexts.Do(c => this.BuildContext(xml, c));
             xml.WriteEndElement();
 
-            Console.WriteLine(sb.ToString());
+            var filePath = Path.Combine(Environment.CurrentDirectory, this.file);
+            using (StreamWriter ostream = new StreamWriter(filePath, false))
+            {
+                ostream.WriteLine(sb.ToString());
+                Console.WriteLine($"Test results published to: {filePath}");
+            }
+            
+                        
+            
         }
 
         void BuildContext(XmlTextWriter xml, Context context)

--- a/NSpec/Domain/Formatters/XUnitFormatter.cs
+++ b/NSpec/Domain/Formatters/XUnitFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -11,15 +12,6 @@ namespace NSpec.Domain.Formatters
     {
         string file;
 
-        public XUnitFormatter(string file)
-        {
-            this.file = file ?? "nspec-results.xml";
-        }
-
-        public XUnitFormatter():this(null)
-        {
-            
-        }
         public void Write(ContextCollection contexts)
         {
             StringBuilder sb = new StringBuilder();
@@ -34,19 +26,26 @@ namespace NSpec.Domain.Formatters
 
             contexts.Do(c => this.BuildContext(xml, c));
             xml.WriteEndElement();
-
-            var filePath = Path.Combine(Environment.CurrentDirectory, this.file);
-            using (StreamWriter ostream = new StreamWriter(filePath, false))
+            var results = sb.ToString();
+            bool didWriteToFile = false;
+            if (Options.ContainsKey("file"))
             {
-                var results = sb.ToString();
-                ostream.WriteLine(results);
-                Console.WriteLine(results);
-                //Console.WriteLine($"Test results published to: {filePath}");
+                var filePath = Path.Combine(Environment.CurrentDirectory, Options["file"]);
+                using (StreamWriter ostream = new StreamWriter(filePath, false))
+                {
+                    ostream.WriteLine(results);
+                    Console.WriteLine($"Test results published to: {filePath}");
+                }
+                didWriteToFile = true;
             }
-            
-                        
-            
+            if (didWriteToFile && Options.ContainsKey("console"))
+                Console.WriteLine(results);
+
+            if (!didWriteToFile)
+                Console.WriteLine(results);
         }
+
+        public IDictionary<string, string> Options { get; set; }
 
         void BuildContext(XmlTextWriter xml, Context context)
         {

--- a/NSpec/Domain/Formatters/XmlFormatter.cs
+++ b/NSpec/Domain/Formatters/XmlFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -26,6 +27,8 @@ namespace NSpec.Domain.Formatters
 
             Console.WriteLine(sb.ToString());
         }
+
+        public IDictionary<string, string> Options { get; set; }
 
         void BuildContext(XmlTextWriter xml, Context context)
         {

--- a/NSpecSpecs/ClassContextBug/NestContextsTests.cs
+++ b/NSpecSpecs/ClassContextBug/NestContextsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Reflection;
 using NSpec;
 using NSpec.Domain;
@@ -63,5 +64,7 @@ namespace NSpecSpecs.ClassContextBug
         {
             this.Contexts = contexts;
         }
+
+        public IDictionary<string, string> Options { get; set; }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/describe_LiveFormatter_with_context_filter.cs
+++ b/NSpecSpecs/describe_RunningSpecs/describe_LiveFormatter_with_context_filter.cs
@@ -97,6 +97,9 @@ namespace NSpecSpecs.describe_RunningSpecs
         {
         }
 
+        public IDictionary<string, string> Options { get; set; }
+
+
         public void Write(Context context)
         {
             WrittenContexts.Add(context);


### PR DESCRIPTION
Update XUnitFormatter to write to nspec-results.xml instead of console. I do some logging on the console as well - so console redirection wasn't an option when I run these tests on the CI server.

