### PR TITLE
feat(context): wrap exceptions from bare code in custom exception

### DIFF
--- a/NSpec/Domain/ContextBareCodeException.cs
+++ b/NSpec/Domain/ContextBareCodeException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace NSpec.Domain
+{
+    public class ContextBareCodeException : Exception
+    {
+        public ContextBareCodeException(Exception innerException)
+            : base(bareCodeMessage, innerException)
+        { }
+
+        const string bareCodeMessage =
+            "While building your test spec, code outside of any test hook threw an exception. " +
+            "The whole context failed building, and this failing test case took its place. " +
+            "Original exception details can be found in 'InnerException' here." +
+            "Please double check your test code and consider running it within 'before' or 'act' hooks.";
+    }
+}

--- a/NSpec/Domain/MethodContext.cs
+++ b/NSpec/Domain/MethodContext.cs
@@ -35,10 +35,7 @@ namespace NSpec.Domain
 
             string exampleName = "Method context body throws an exception of type {0}".With(reportedEx.GetType().Name);
 
-            // TODO create a specific exception type (e.g. BareCodeException) wrapping original reported exception
-            // specific exception should explain more accurately to user what happened
-
-            instance.it[exampleName] = () => { throw reportedEx; };
+            instance.it[exampleName] = () => { throw new ContextBareCodeException(reportedEx); };
         }
 
         MethodInfo method;

--- a/NSpec/Domain/MethodContext.cs
+++ b/NSpec/Domain/MethodContext.cs
@@ -33,7 +33,10 @@ namespace NSpec.Domain
                 ? targetEx.InnerException
                 : targetEx;
 
-            string exampleName = "{0} throws an exception of type {1}".With(method.Name, reportedEx.GetType().Name);
+            string exampleName = "Method context body throws an exception of type {0}".With(reportedEx.GetType().Name);
+
+            // TODO create a specific exception type (e.g. BareCodeException) wrapping original reported exception
+            // specific exception should explain more accurately to user what happened
 
             instance.it[exampleName] = () => { throw reportedEx; };
         }

--- a/NSpec/Domain/MethodContext.cs
+++ b/NSpec/Domain/MethodContext.cs
@@ -13,11 +13,11 @@ namespace NSpec.Domain
             {
                 method.Invoke(instance, null);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Console.WriteLine("Exception executing context: {0}".With(FullContext()));
+                Console.WriteLine("Exception executing method-level context: {0}".With(FullContext()));
 
-                throw e;
+                AddFailingExample(instance, ex);
             }
         }
 
@@ -25,6 +25,17 @@ namespace NSpec.Domain
             : base(method.Name, tags)
         {
             this.method = method;
+        }
+
+        void AddFailingExample(nspec instance, Exception targetEx)
+        {
+            var reportedEx = (targetEx.InnerException != null)
+                ? targetEx.InnerException
+                : targetEx;
+
+            string exampleName = "{0} throws an exception of type {1}".With(method.Name, reportedEx.GetType().Name);
+
+            instance.it[exampleName] = () => { /* TODO Fill failing example body */ };
         }
 
         MethodInfo method;

--- a/NSpec/Domain/MethodContext.cs
+++ b/NSpec/Domain/MethodContext.cs
@@ -35,7 +35,7 @@ namespace NSpec.Domain
 
             string exampleName = "{0} throws an exception of type {1}".With(method.Name, reportedEx.GetType().Name);
 
-            instance.it[exampleName] = () => { /* TODO Fill failing example body */ };
+            instance.it[exampleName] = () => { throw reportedEx; };
         }
 
         MethodInfo method;

--- a/NSpec/NSpec.csproj
+++ b/NSpec/NSpec.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Domain\AsyncMethodLevelHooks.cs" />
     <Compile Include="Domain\ClassContext.cs" />
     <Compile Include="Domain\AsyncExample.cs" />
+    <Compile Include="Domain\ContextBareCodeException.cs" />
     <Compile Include="Domain\ExampleBase.cs" />
     <Compile Include="Domain\ExampleFailureException.cs" />
     <Compile Include="Domain\Formatters\ConsoleFormatter.cs" />

--- a/NSpec/nspec.cs
+++ b/NSpec/nspec.cs
@@ -460,9 +460,28 @@ namespace NSpec
 
             Context = context;
 
-            action();
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Exception executing context: {0}".With(context.FullContext()));
+
+                AddFailingExample(ex);
+            }
 
             Context = beforeContext;
+        }
+
+        void AddFailingExample(Exception reportedEx)
+        {
+            string exampleName = "Context body throws an exception of type {0}".With(reportedEx.GetType().Name);
+
+            // TODO create a specific exception type (e.g. BareCodeException) wrapping original reported exception
+            // specific exception should explain more accurately to user what happened
+
+            it[exampleName] = () => { throw reportedEx; };
         }
 
         void AssertExpectedException<T>(Exception actualException, string expectedMessage) where T : Exception

--- a/NSpec/nspec.cs
+++ b/NSpec/nspec.cs
@@ -478,10 +478,7 @@ namespace NSpec
         {
             string exampleName = "Context body throws an exception of type {0}".With(reportedEx.GetType().Name);
 
-            // TODO create a specific exception type (e.g. BareCodeException) wrapping original reported exception
-            // specific exception should explain more accurately to user what happened
-
-            it[exampleName] = () => { throw reportedEx; };
+            it[exampleName] = () => { throw new ContextBareCodeException(reportedEx); };
         }
 
         void AssertExpectedException<T>(Exception actualException, string expectedMessage) where T : Exception

--- a/NSpecSpecs/NSpecSpecs.csproj
+++ b/NSpecSpecs/NSpecSpecs.csproj
@@ -139,6 +139,7 @@
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_after_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_before_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_method_level_before_contains_exception.cs" />
+    <Compile Include="describe_RunningSpecs\Exceptions\when_method_level_context_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\when_describing_async_hooks.cs" />
     <Compile Include="ExampleBaseWrap.cs" />
     <Compile Include="SpecExtensions.cs" />

--- a/NSpecSpecs/NSpecSpecs.csproj
+++ b/NSpecSpecs/NSpecSpecs.csproj
@@ -69,6 +69,7 @@
     <Compile Include="describe_Assertions.cs" />
     <Compile Include="describe_cecil.cs" />
     <Compile Include="describe_Conventions.cs" />
+    <Compile Include="describe_MethodContext.cs" />
     <Compile Include="describe_output.cs" />
     <Compile Include="describe_RunningSpecs\describe_async_after_all.cs" />
     <Compile Include="describe_RunningSpecs\describe_async_after.cs" />

--- a/NSpecSpecs/NSpecSpecs.csproj
+++ b/NSpecSpecs/NSpecSpecs.csproj
@@ -140,6 +140,7 @@
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_before_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_method_level_before_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_method_level_context_contains_exception.cs" />
+    <Compile Include="describe_RunningSpecs\Exceptions\when_sub_context_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\when_describing_async_hooks.cs" />
     <Compile Include="ExampleBaseWrap.cs" />
     <Compile Include="SpecExtensions.cs" />

--- a/NSpecSpecs/describe_Context.cs
+++ b/NSpecSpecs/describe_Context.cs
@@ -196,7 +196,7 @@ namespace NSpecNUnit
         Context contextWithExample;
 
         Context contextWithoutExample;
-        
+
         [SetUp]
         public void given_nested_contexts_with_and_without_executed_examples()
         {

--- a/NSpecSpecs/describe_Context.cs
+++ b/NSpecSpecs/describe_Context.cs
@@ -294,6 +294,7 @@ namespace NSpecNUnit
 
     [TestFixture]
     [Category("Context")]
+    [Category("BareCode")]
     public class when_bare_code_throws
     {
         public class SpecClass : nspec

--- a/NSpecSpecs/describe_MethodContext.cs
+++ b/NSpecSpecs/describe_MethodContext.cs
@@ -8,6 +8,7 @@ namespace NSpecSpecs
 {
     [TestFixture]
     [Category("MethodContext")]
+    [Category("BareCode")]
     public class when_bare_code_throws
     {
         public class SpecClass : nspec

--- a/NSpecSpecs/describe_MethodContext.cs
+++ b/NSpecSpecs/describe_MethodContext.cs
@@ -1,0 +1,64 @@
+using NSpec;
+using NSpec.Domain;
+using NSpecSpecs.describe_RunningSpecs.Exceptions;
+using NUnit.Framework;
+using System.Linq;
+
+namespace NSpecSpecs
+{
+    [TestFixture]
+    [Category("MethodContext")]
+    public class when_bare_code_throws
+    {
+        public class SpecClass : nspec
+        {
+            public void Given_some_context()
+            {
+                DoSomethingThatThrows();
+
+                before = () => { };
+
+                it["Should pass"] = () => { };
+            }
+
+            void DoSomethingThatThrows()
+            {
+                throw new KnownException("Bare code threw exception");
+            }
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            var specType = typeof(SpecClass);
+
+            classContext = new ClassContext(specType);
+
+            var methodInfo = specType.GetMethod("Given_some_context");
+
+            var methodContext = new MethodContext(methodInfo);
+
+            classContext.AddContext(methodContext);
+        }
+
+        [Test]
+        public void building_should_not_throw()
+        {
+            Assert.DoesNotThrow(() => classContext.Build());
+        }
+
+        [Test]
+        public void it_should_add_example_named_after_context_and_exception()
+        {
+            string expected = "SpecClass. Given some context. Given_some_context throws an exception of type KnownException.";
+
+            classContext.Build();
+
+            string actual = classContext.AllExamples().Single().FullName();
+
+            actual.should_be(expected);
+        }
+
+        ClassContext classContext;
+    }
+}

--- a/NSpecSpecs/describe_MethodContext.cs
+++ b/NSpecSpecs/describe_MethodContext.cs
@@ -12,13 +12,13 @@ namespace NSpecSpecs
     {
         public class SpecClass : nspec
         {
-            public void Given_some_context()
+            public void method_level_context()
             {
                 DoSomethingThatThrows();
 
                 before = () => { };
 
-                it["Should pass"] = () => { };
+                it["should pass"] = () => { };
             }
 
             void DoSomethingThatThrows()
@@ -34,7 +34,7 @@ namespace NSpecSpecs
 
             classContext = new ClassContext(specType);
 
-            var methodInfo = specType.GetMethod("Given_some_context");
+            var methodInfo = specType.GetMethod("method_level_context");
 
             var methodContext = new MethodContext(methodInfo);
 
@@ -50,7 +50,7 @@ namespace NSpecSpecs
         [Test]
         public void it_should_add_example_named_after_context_and_exception()
         {
-            string expected = "SpecClass. Given some context. Given_some_context throws an exception of type KnownException.";
+            string expected = "SpecClass. method level context. method_level_context throws an exception of type KnownException.";
 
             classContext.Build();
 

--- a/NSpecSpecs/describe_MethodContext.cs
+++ b/NSpecSpecs/describe_MethodContext.cs
@@ -50,7 +50,7 @@ namespace NSpecSpecs
         [Test]
         public void it_should_add_example_named_after_context_and_exception()
         {
-            string expected = "SpecClass. method level context. method_level_context throws an exception of type KnownException.";
+            string expected = "SpecClass. method level context. Method context body throws an exception of type KnownException.";
 
             classContext.Build();
 

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
@@ -34,7 +34,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [Test]
         public void example_named_after_context_should_fail_with_same_exception()
         {
-            var example = TheExample("method_level_context throws an exception of type KnownException");
+            var example = TheExample("Method context body throws an exception of type KnownException");
 
             example.Exception.GetType().should_be(typeof(KnownException));
         }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
@@ -1,11 +1,14 @@
 using NSpec;
+using NSpec.Domain;
 using NSpecSpecs.WhenRunningSpecs;
 using NUnit.Framework;
+using System;
 
 namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 {
     [TestFixture]
     [Category("RunningSpecs")]
+    [Category("BareCode")]
     public class when_method_level_context_contains_exception : when_running_specs
     {
         public class SpecClass : nspec
@@ -21,8 +24,14 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 
             void DoSomethingThatThrows()
             {
-                throw new KnownException("Bare code threw exception");
+                var specEx = new KnownException("Bare code threw exception");
+
+                SpecException = specEx;
+
+                throw specEx;
             }
+
+            public static Exception SpecException;
         }
 
         [SetUp]
@@ -32,11 +41,19 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         }
 
         [Test]
-        public void example_named_after_context_should_fail_with_same_exception()
+        public void example_named_after_context_should_fail_with_bare_code_exception()
         {
             var example = TheExample("Method context body throws an exception of type KnownException");
 
-            example.Exception.GetType().should_be(typeof(KnownException));
+            example.Exception.GetType().should_be(typeof(ContextBareCodeException));
+        }
+
+        [Test]
+        public void bare_code_exception_should_wrap_spec_exception()
+        {
+            var example = TheExample("Method context body throws an exception of type KnownException");
+
+            example.Exception.InnerException.should_be(SpecClass.SpecException);
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
@@ -1,0 +1,42 @@
+using NSpec;
+using NSpecSpecs.WhenRunningSpecs;
+using NUnit.Framework;
+
+namespace NSpecSpecs.describe_RunningSpecs.Exceptions
+{
+    [TestFixture]
+    [Category("RunningSpecs")]
+    public class when_method_level_context_contains_exception : when_running_specs
+    {
+        public class SpecClass : nspec
+        {
+            public void method_level_context()
+            {
+                DoSomethingThatThrows();
+
+                before = () => { };
+
+                it["should pass"] = () => { };
+            }
+
+            void DoSomethingThatThrows()
+            {
+                throw new KnownException("Bare code threw exception");
+            }
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            Run(typeof(SpecClass));
+        }
+
+        [Test]
+        public void example_named_after_context_should_fail_with_same_exception()
+        {
+            var example = TheExample("method_level_context throws an exception of type KnownException");
+
+            example.Exception.GetType().should_be(typeof(KnownException));
+        }
+    }
+}

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
@@ -1,11 +1,14 @@
 using NSpec;
+using NSpec.Domain;
 using NSpecSpecs.WhenRunningSpecs;
 using NUnit.Framework;
+using System;
 
 namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 {
     [TestFixture]
     [Category("RunningSpecs")]
+    [Category("BareCode")]
     public class when_sub_context_contains_exception : when_running_specs
     {
         public class SpecClass : nspec
@@ -24,8 +27,14 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 
             void DoSomethingThatThrows()
             {
-                throw new KnownException("Bare code threw exception");
+                var specEx = new KnownException("Bare code threw exception");
+
+                SpecException = specEx;
+
+                throw specEx;
             }
+
+            public static Exception SpecException;
         }
 
         [SetUp]
@@ -35,11 +44,19 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         }
 
         [Test]
-        public void example_named_after_context_should_fail_with_same_exception()
+        public void example_named_after_context_should_fail_with_bare_code_exception()
         {
             var example = TheExample("Context body throws an exception of type KnownException");
 
-            example.Exception.GetType().should_be(typeof(KnownException));
+            example.Exception.GetType().should_be(typeof(ContextBareCodeException));
+        }
+
+        [Test]
+        public void bare_code_exception_should_wrap_spec_exception()
+        {
+            var example = TheExample("Context body throws an exception of type KnownException");
+
+            example.Exception.InnerException.should_be(SpecClass.SpecException);
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
@@ -1,0 +1,45 @@
+using NSpec;
+using NSpecSpecs.WhenRunningSpecs;
+using NUnit.Framework;
+
+namespace NSpecSpecs.describe_RunningSpecs.Exceptions
+{
+    [TestFixture]
+    [Category("RunningSpecs")]
+    public class when_sub_context_contains_exception : when_running_specs
+    {
+        public class SpecClass : nspec
+        {
+            public void method_level_context()
+            {
+                context["sub level context"] = () =>
+                {
+                    DoSomethingThatThrows();
+
+                    before = () => { };
+
+                    it["should pass"] = () => { };
+                };
+            }
+
+            void DoSomethingThatThrows()
+            {
+                throw new KnownException("Bare code threw exception");
+            }
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            Run(typeof(SpecClass));
+        }
+
+        [Test]
+        public void example_named_after_context_should_fail_with_same_exception()
+        {
+            var example = TheExample("Context body throws an exception of type KnownException");
+
+            example.Exception.GetType().should_be(typeof(KnownException));
+        }
+    }
+}


### PR DESCRIPTION
When user test code outside of any test hook (so-called *bare code*) throws an exception, nspec fails building the current context subtree and Visual Studio users (in particular) are left with no clear explanation.

With current PR, exceptions from bare code are caught and a synthetic failing spec is added in place of missing context. The spec explains what happened and wraps original exception in an nspec-specific exception.

See #123 for original discussion.