### PR TITLE
Report elapsed time for each spec

### DIFF
--- a/NSpec/Domain/Context.cs
+++ b/NSpec/Domain/Context.cs
@@ -2,6 +2,7 @@
 using NSpec.Domain.Formatters;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -331,10 +332,11 @@ namespace NSpec.Domain
                 Action<nspec> dummyExampleRunner = _ => HandleSkipped(example);
 
                 RunAndHandleException(dummyExampleRunner, nspec, ref example.Exception);
-
+                
                 return;
             }
-
+            var sw = new Stopwatch();
+            sw.Start();
             RunAndHandleException(RunBefores, nspec, ref Exception);
 
             RunAndHandleException(RunActs, nspec, ref Exception);
@@ -345,7 +347,8 @@ namespace NSpec.Domain
 
             // when an expected exception is thrown and is set to be cleared by 'expect<>',
             // a subsequent exception thrown in 'after' hooks would go unnoticed, so do not clear in this case
-
+            sw.Stop();
+            example.Duration = sw.Elapsed;
             if (exceptionThrownInAfters) ClearExpectedException = false;
         }
 

--- a/NSpec/Domain/ExampleBase.cs
+++ b/NSpec/Domain/ExampleBase.cs
@@ -34,6 +34,7 @@ namespace NSpec.Domain
         public abstract void Run(nspec nspec);
 
         public abstract bool IsAsync { get; }
+        public TimeSpan Duration { get; set; }
 
         public string FullName()
         {

--- a/NSpec/Domain/Formatters/ConsoleFormatter.cs
+++ b/NSpec/Domain/Formatters/ConsoleFormatter.cs
@@ -41,14 +41,14 @@ namespace NSpec.Domain.Formatters
             string duration;
             if (e.Duration.TotalMinutes > 1)
             {
-                duration = $" ({e.Duration.Minutes}min {e.Duration.Seconds}s)";
+                duration = string.Format(" ({0}min {1}s)", e.Duration.Minutes, e.Duration.Seconds);
             }else if (e.Duration.TotalSeconds > 1)
             {
-                duration = $" ({e.Duration.TotalSeconds:F0}s)";
+                duration = string.Format(" ({0:F0}s)", e.Duration.TotalSeconds);
             }
             else
             {
-                duration = $" ({e.Duration.TotalMilliseconds:F0}ms)";
+                duration = string.Format(" ({0:F0}ms)", e.Duration.TotalMilliseconds);
             }
                                                             
             var result = e.Pending ? whiteSpace + e.Spec + " - PENDING" : whiteSpace + e.Spec + duration + failureMessage;

--- a/NSpec/Domain/Formatters/ConsoleFormatter.cs
+++ b/NSpec/Domain/Formatters/ConsoleFormatter.cs
@@ -38,8 +38,20 @@ namespace NSpec.Domain.Formatters
             var failureMessage = noFailure ? "" : " - FAILED - {0}".With(e.Exception.CleanMessage());
 
             var whiteSpace = indent.Times(level);
-
-            var result = e.Pending ? whiteSpace + e.Spec + " - PENDING" : whiteSpace + e.Spec + failureMessage;
+            string duration;
+            if (e.Duration.TotalMinutes > 1)
+            {
+                duration = $" ({e.Duration.Minutes}min {e.Duration.Seconds}s)";
+            }else if (e.Duration.TotalSeconds > 1)
+            {
+                duration = $" ({e.Duration.TotalSeconds:F0}s)";
+            }
+            else
+            {
+                duration = $" ({e.Duration.TotalMilliseconds:F0}ms)";
+            }
+                                                            
+            var result = e.Pending ? whiteSpace + e.Spec + " - PENDING" : whiteSpace + e.Spec + duration + failureMessage;
 
             Console.ForegroundColor = ConsoleColor.Green;
 


### PR DESCRIPTION
It's useful to see elapsed time for each spec.

```
Dummy Specs
  describe dummy
    should run (22ms)
    takes longer (1s)

2 Examples, 0 Failed, 0 Pending
```