### PR TITLE
Ordered specs

### DIFF
--- a/NSpec/Domain/ContextBuilder.cs
+++ b/NSpec/Domain/ContextBuilder.cs
@@ -15,7 +15,7 @@ namespace NSpec.Domain
 
             conventions.Initialize();
 
-            var specClasses = finder.SpecClasses();
+            var specClasses = finder.SpecClasses().OrderBy(type => type.Name);
 
             var container = new ClassContext(typeof(nspec), conventions, tagsFilter);
 


### PR DESCRIPTION
I'm writing outside-in API tests... IN that context, having a known execution order of classes helps. This PR sorts spec types by name so that tests can run like
S01_Something_Specs
S02_Something_else_specs
