### PR TITLE
feat(bareCode): avoid blow up with exception in spec class c'tor

### DIFF
--- a/NSpec/Domain/ContextBareCodeException.cs
+++ b/NSpec/Domain/ContextBareCodeException.cs
@@ -10,7 +10,7 @@ namespace NSpec.Domain
 
         const string bareCodeMessage =
             "While building your test spec, code outside of any test hook threw an exception. " +
-            "The whole context failed building, and this failing test case took its place. " +
+            "The whole class or context failed building, and this failing test case took its place. " +
             "Original exception details can be found in 'InnerException' here." +
             "Please double check your test code and consider running it within 'before' or 'act' hooks.";
     }

--- a/NSpec/Domain/MethodContext.cs
+++ b/NSpec/Domain/MethodContext.cs
@@ -31,7 +31,7 @@ namespace NSpec.Domain
                 ? targetEx.InnerException
                 : targetEx;
 
-            string exampleName = "Method context body throws an exception of type {0}".With(reportedEx.GetType().Name);
+            string exampleName = "Method context body throws an exception of type '{0}'".With(reportedEx.GetType().Name);
 
             instance.it[exampleName] = () => { throw new ContextBareCodeException(reportedEx); };
         }

--- a/NSpec/nspec.cs
+++ b/NSpec/nspec.cs
@@ -474,7 +474,7 @@ namespace NSpec
 
         void AddFailingExample(Exception reportedEx)
         {
-            string exampleName = "Context body throws an exception of type {0}".With(reportedEx.GetType().Name);
+            string exampleName = "Context body throws an exception of type '{0}'".With(reportedEx.GetType().Name);
 
             it[exampleName] = () => { throw new ContextBareCodeException(reportedEx); };
         }

--- a/NSpecSpecs/NSpecSpecs.csproj
+++ b/NSpecSpecs/NSpecSpecs.csproj
@@ -140,6 +140,7 @@
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_before_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_async_method_level_before_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_method_level_context_contains_exception.cs" />
+    <Compile Include="describe_RunningSpecs\Exceptions\when_spec_class_ctor_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\Exceptions\when_sub_context_contains_exception.cs" />
     <Compile Include="describe_RunningSpecs\when_describing_async_hooks.cs" />
     <Compile Include="ExampleBaseWrap.cs" />

--- a/NSpecSpecs/describe_Context.cs
+++ b/NSpecSpecs/describe_Context.cs
@@ -315,6 +315,8 @@ namespace NSpecNUnit
             {
                 throw new KnownException("Bare code threw exception");
             }
+
+            public static string ExceptionTypeName = typeof(KnownException).Name;
         }
 
         [SetUp]
@@ -338,15 +340,13 @@ namespace NSpecNUnit
         }
 
         [Test]
-        public void it_should_add_example_named_after_context_and_exception()
+        public void it_should_add_example_named_after_exception()
         {
-            string expected = "SpecClass. method level context. sub level context. Context body throws an exception of type KnownException.";
-
             classContext.Build();
 
             string actual = classContext.AllExamples().Single().FullName();
 
-            actual.should_be(expected);
+            actual.should_contain(SpecClass.ExceptionTypeName);
         }
 
         ClassContext classContext;

--- a/NSpecSpecs/describe_MethodContext.cs
+++ b/NSpecSpecs/describe_MethodContext.cs
@@ -26,6 +26,8 @@ namespace NSpecSpecs
             {
                 throw new KnownException("Bare code threw exception");
             }
+
+            public static string ExceptionTypeName = typeof(KnownException).Name;
         }
 
         [SetUp]
@@ -49,15 +51,13 @@ namespace NSpecSpecs
         }
 
         [Test]
-        public void it_should_add_example_named_after_context_and_exception()
+        public void it_should_add_example_named_after_exception()
         {
-            string expected = "SpecClass. method level context. Method context body throws an exception of type KnownException.";
-
             classContext.Build();
 
             string actual = classContext.AllExamples().Single().FullName();
 
-            actual.should_be(expected);
+            actual.should_contain(SpecClass.ExceptionTypeName);
         }
 
         ClassContext classContext;

--- a/NSpecSpecs/describe_MethodContext.cs
+++ b/NSpecSpecs/describe_MethodContext.cs
@@ -9,7 +9,7 @@ namespace NSpecSpecs
     [TestFixture]
     [Category("MethodContext")]
     [Category("BareCode")]
-    public class when_bare_code_throws
+    public class when_bare_code_throws_in_method_context
     {
         public class SpecClass : nspec
         {

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
@@ -3,6 +3,7 @@ using NSpec.Domain;
 using NSpecSpecs.WhenRunningSpecs;
 using NUnit.Framework;
 using System;
+using System.Linq;
 
 namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 {
@@ -32,6 +33,8 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             }
 
             public static Exception SpecException;
+
+            public static string ExceptionTypeName = typeof(KnownException).Name;
         }
 
         [SetUp]
@@ -41,9 +44,17 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         }
 
         [Test]
-        public void example_named_after_context_should_fail_with_bare_code_exception()
+        public void synthetic_example_name_should_show_exception()
         {
-            var example = TheExample("Method context body throws an exception of type KnownException");
+            var example = FindSyntheticExample();
+
+            example.should_not_be_null();
+        }
+
+        [Test]
+        public void synthetic_example_should_fail_with_bare_code_exception()
+        {
+            var example = FindSyntheticExample();
 
             example.Exception.GetType().should_be(typeof(ContextBareCodeException));
         }
@@ -51,9 +62,22 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [Test]
         public void bare_code_exception_should_wrap_spec_exception()
         {
-            var example = TheExample("Method context body throws an exception of type KnownException");
+            var example = FindSyntheticExample();
 
             example.Exception.InnerException.should_be(SpecClass.SpecException);
+        }
+
+        ExampleBase FindSyntheticExample()
+        {
+            var filteredExamples =
+                from exm in AllExamples()
+                let fullname = exm.FullName()
+                where fullname.Contains(SpecClass.ExceptionTypeName)
+                select exm;
+
+            var example = filteredExamples.FirstOrDefault();
+
+            return example;
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_spec_class_ctor_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_spec_class_ctor_contains_exception.cs
@@ -1,0 +1,85 @@
+﻿using NSpec;
+using NSpec.Domain;
+using NSpecSpecs.WhenRunningSpecs;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace NSpecSpecs.describe_RunningSpecs.Exceptions
+{
+    [TestFixture]
+    [Category("RunningSpecs")]
+    [Category("BareCode")]
+    public class when_spec_class_ctor_contains_exception : when_running_specs
+    {
+        public class SpecClass : nspec
+        {
+            readonly object someTestObject = DoSomethingThatThrows();
+
+            public void method_level_context()
+            {
+                before = () => { };
+
+                it["should pass"] = () => { };
+            }
+
+            static object DoSomethingThatThrows()
+            {
+                var specEx = new KnownException("Bare code threw exception");
+
+                SpecException = specEx;
+
+                throw specEx;
+            }
+
+            public static Exception SpecException;
+
+            public static string TypeFullName = typeof(SpecClass).FullName;
+            public static string ExceptionTypeName = typeof(KnownException).Name;
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            Run(typeof(SpecClass));
+        }
+
+        [Test]
+        public void synthetic_example_name_should_show_class_and_exception()
+        {
+            var example = FindSyntheticExample();
+
+            example.should_not_be_null();
+        }
+
+        [Test]
+        public void synthetic_example_should_fail_with_bare_code_exception()
+        {
+            var example = FindSyntheticExample();
+
+            example.Exception.GetType().should_be(typeof(ContextBareCodeException));
+        }
+
+        [Test]
+        public void bare_code_exception_should_wrap_spec_exception()
+        {
+            var example = FindSyntheticExample();
+
+            example.Exception.InnerException.should_be(SpecClass.SpecException);
+        }
+
+        ExampleBase FindSyntheticExample()
+        {
+            var filteredExamples =
+                from exm in AllExamples()
+                let fullname = exm.FullName()
+                where fullname.Contains(SpecClass.TypeFullName) &&
+                    fullname.Contains(SpecClass.ExceptionTypeName)
+                select exm;
+
+            var example = filteredExamples.FirstOrDefault();
+
+            return example;
+        }
+    }
+}

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
@@ -3,6 +3,7 @@ using NSpec.Domain;
 using NSpecSpecs.WhenRunningSpecs;
 using NUnit.Framework;
 using System;
+using System.Linq;
 
 namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 {
@@ -35,6 +36,8 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             }
 
             public static Exception SpecException;
+
+            public static string ExceptionTypeName = typeof(KnownException).Name;
         }
 
         [SetUp]
@@ -44,9 +47,17 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         }
 
         [Test]
-        public void example_named_after_context_should_fail_with_bare_code_exception()
+        public void synthetic_example_name_should_show_exception()
         {
-            var example = TheExample("Context body throws an exception of type KnownException");
+            var example = FindSyntheticExample();
+
+            example.should_not_be_null();
+        }
+
+        [Test]
+        public void synthetic_example_should_fail_with_bare_code_exception()
+        {
+            var example = FindSyntheticExample();
 
             example.Exception.GetType().should_be(typeof(ContextBareCodeException));
         }
@@ -54,9 +65,22 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [Test]
         public void bare_code_exception_should_wrap_spec_exception()
         {
-            var example = TheExample("Context body throws an exception of type KnownException");
+            var example = FindSyntheticExample();
 
             example.Exception.InnerException.should_be(SpecClass.SpecException);
+        }
+
+        ExampleBase FindSyntheticExample()
+        {
+            var filteredExamples =
+                from exm in AllExamples()
+                let fullname = exm.FullName()
+                where fullname.Contains(SpecClass.ExceptionTypeName)
+                select exm;
+
+            var example = filteredExamples.FirstOrDefault();
+
+            return example;
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/describe_LiveFormatter_with_context_filter.cs
+++ b/NSpecSpecs/describe_RunningSpecs/describe_LiveFormatter_with_context_filter.cs
@@ -22,7 +22,7 @@ namespace NSpecSpecs.describe_RunningSpecs
             {
                 context["a context with an example"] = () =>
                 {
-                    it["1 is 1"] = () => 1.Is(1);
+                    it["liveconsole: 1 is 1"] = () => 1.Is(1);
                 };
             }
 
@@ -42,7 +42,7 @@ namespace NSpecSpecs.describe_RunningSpecs
         [Test]
         public void it_writes_the_example()
         {
-            formatter.WrittenExamples.should_contain(contexts.FindExample("1 is 1"));
+            formatter.WrittenExamples.should_contain(contexts.FindExample("liveconsole: 1 is 1"));
         }
 
         [Test]


### PR DESCRIPTION
1. Don't blow up VS test runner when discovering specs that throw an exception in constructor (or field initialization)
1. Highlight when an NSpecSpecs test looks for an example with duplicated name