### PR TITLE
redirect & capture console output and display in context

### DIFF
--- a/NSpec/Domain/Context.cs
+++ b/NSpec/Domain/Context.cs
@@ -3,6 +3,7 @@ using NSpec.Domain.Formatters;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -251,14 +252,22 @@ namespace NSpec.Domain
 
                 if (failFast && example.Context.HasAnyFailures()) return;
 
+                var stringWriter = new StringWriter();
+                var stdout = Console.Out;
+                var stderr = Console.Error;
+                Console.SetOut(stringWriter);
+                Console.SetError(stringWriter);
                 Exercise(example, nspec);
 
+                example.CapturedOutput = stringWriter.ToString();
+                Console.SetOut(stdout);
+                Console.SetError(stderr);
                 if (example.HasRun && !alreadyWritten)
                 {
                     WriteAncestors(formatter);
                     alreadyWritten = true;
                 }
-
+                
                 if (example.HasRun) formatter.Write(example, Level);
             }
 

--- a/NSpec/Domain/Context.cs
+++ b/NSpec/Domain/Context.cs
@@ -242,9 +242,16 @@ namespace NSpec.Domain
             var nspec = savedInstance ?? instance;
 
             bool runBeforeAfterAll = AnyUnfilteredExampleInSubTree(nspec);
+            var stringWriter = new StringWriter();
+            var stdout = Console.Out;
+            var stderr = Console.Error;
+            Console.SetOut(stringWriter);
+            Console.SetError(stringWriter);
 
             if (runBeforeAfterAll) RunAndHandleException(RunBeforeAll, nspec, ref ExceptionBeforeAll);
-
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            this.CapturedOutput = stringWriter.ToString();
             // intentionally using for loop to prevent collection was modified error in sample specs
             for (int i = 0; i < Examples.Count; i++)
             {
@@ -252,9 +259,9 @@ namespace NSpec.Domain
 
                 if (failFast && example.Context.HasAnyFailures()) return;
 
-                var stringWriter = new StringWriter();
-                var stdout = Console.Out;
-                var stderr = Console.Error;
+                stringWriter = new StringWriter();
+                stdout = Console.Out;
+                stderr = Console.Error;
                 Console.SetOut(stringWriter);
                 Console.SetError(stringWriter);
                 Exercise(example, nspec);
@@ -275,6 +282,8 @@ namespace NSpec.Domain
 
             if (runBeforeAfterAll) RunAndHandleException(RunAfterAll, nspec, ref ExceptionAfterAll);
         }
+
+        public string CapturedOutput { get; set; }
 
         /// <summary>
         /// Test execution happens in two phases: this is the second phase.

--- a/NSpec/Domain/ExampleBase.cs
+++ b/NSpec/Domain/ExampleBase.cs
@@ -37,6 +37,7 @@ namespace NSpec.Domain
 
         public abstract bool IsAsync { get; }
         public TimeSpan Duration { get; set; }
+        public string CapturedOutput { get; set; }
 
         public string FullName()
         {

--- a/NSpec/Domain/Formatters/ConsoleFormatter.cs
+++ b/NSpec/Domain/Formatters/ConsoleFormatter.cs
@@ -62,6 +62,14 @@ namespace NSpec.Domain.Formatters
             WriteLineDelegate(result);
 
             Console.ForegroundColor = ConsoleColor.White;
+            if (!string.IsNullOrWhiteSpace(e.CapturedOutput))
+            {
+                WriteLineDelegate(indent.Times(level + 1) + "//Console output");
+                foreach (var line in e.CapturedOutput.TrimEnd('\n').Split('\n'))
+                {
+                    WriteLineDelegate(indent.Times(level + 1) + line);
+                }
+            }
         }
 
         public string FailureSummary(ContextCollection contexts)

--- a/NSpec/Domain/Formatters/ConsoleFormatter.cs
+++ b/NSpec/Domain/Formatters/ConsoleFormatter.cs
@@ -29,6 +29,14 @@ namespace NSpec.Domain.Formatters
             if (context.Level == 1) WriteLineDelegate("");
 
             WriteLineDelegate(indent.Times(context.Level - 1) + context.Name);
+            if (!string.IsNullOrEmpty(context.CapturedOutput))
+            {
+                WriteLineDelegate(indent.Times(context.Level - 1) + "//Console output");
+                foreach (var l in context.CapturedOutput.TrimEnd('\n').Split('\n'))
+                {
+                    WriteLineDelegate(indent.Times(context.Level - 1) + l);
+                }
+            }
         }
 
         public void Write(ExampleBase e, int level)

--- a/NSpec/Domain/Formatters/XUnitFormatter.cs
+++ b/NSpec/Domain/Formatters/XUnitFormatter.cs
@@ -75,6 +75,7 @@ namespace NSpec.Domain.Formatters
 
             xml.WriteAttributeString("classname", className.ToString());
             xml.WriteAttributeString("name", testName);
+            xml.WriteAttributeString("time", example.Duration.TotalSeconds.ToString("F2"));
 
             if (example.Exception != null)
             {
@@ -84,7 +85,12 @@ namespace NSpec.Domain.Formatters
                 xml.WriteString(example.Exception.ToString());
                 xml.WriteEndElement();
             }
-
+            if (!string.IsNullOrWhiteSpace(example.CapturedOutput))
+            {
+                xml.WriteStartElement("system-out");
+                xml.WriteCData("\n" + example.CapturedOutput);
+                xml.WriteEndElement();
+            }
             xml.WriteEndElement();
         }
 

--- a/NSpecSpecs/NSpecSpecs.csproj
+++ b/NSpecSpecs/NSpecSpecs.csproj
@@ -68,9 +68,11 @@
     <Compile Include="DebuggerShim.cs" />
     <Compile Include="describe_Assertions.cs" />
     <Compile Include="describe_cecil.cs" />
+    <Compile Include="describe_context_output_capture.cs" />
     <Compile Include="describe_Conventions.cs" />
     <Compile Include="describe_MethodContext.cs" />
     <Compile Include="describe_output.cs" />
+    <Compile Include="describe_output_capture.cs" />
     <Compile Include="describe_RunningSpecs\describe_async_after_all.cs" />
     <Compile Include="describe_RunningSpecs\describe_async_after.cs" />
     <Compile Include="describe_RunningSpecs\describe_async_act.cs" />

--- a/NSpecSpecs/describe_context_output_capture.cs
+++ b/NSpecSpecs/describe_context_output_capture.cs
@@ -1,0 +1,48 @@
+using System;
+using NSpec;
+
+namespace NSpecSpecs
+{
+    public class describe_context_output_capture : nspec
+    {
+        void before_all()
+        {
+            Console.WriteLine("this is before all");
+        }
+        void output_capture()
+        {
+            beforeAll = () =>
+            {
+                Console.WriteLine("this is context before all");
+            };
+
+            beforeEach = () =>
+            {
+                Console.WriteLine("this is before each");
+            };
+
+            it["should capture output"] = () =>
+            {
+                Console.WriteLine("this is console output");
+            };
+        }
+    }
+
+    public static class describe_context_output_capture_output
+    {
+        public static string Output = @"
+describe context output capture
+//Console output
+this is before all
+  output capture
+  //Console output
+  this is context before all
+    should capture output
+      //Console output
+      this is before each
+      this is console output
+
+1 Examples, 0 Failed, 0 Pending
+";
+    }
+}

--- a/NSpecSpecs/describe_output.cs
+++ b/NSpecSpecs/describe_output.cs
@@ -69,7 +69,13 @@ namespace NSpecSpecs
                   ""),
          TestCase(typeof(describe_focus_output),
                   new [] { typeof(describe_focus) },
-                  "focus")]
+                  "focus"),
+         TestCase(typeof(describe_output_capture_output),
+                    new[] {typeof(describe_output_capture)},
+                    ""),
+         TestCase(typeof(describe_context_output_capture_output),
+                    new[] { typeof(describe_context_output_capture) },
+                    "")]
 
         public void output_verification(Type output, Type []testClasses, string tags)
         {

--- a/NSpecSpecs/describe_output_capture.cs
+++ b/NSpecSpecs/describe_output_capture.cs
@@ -1,0 +1,29 @@
+using System;
+using NSpec;
+
+namespace NSpecSpecs
+{
+    public class describe_output_capture : nspec
+    {
+        void output_capture()
+        {
+            it["should capture output"] = () =>
+            {
+                Console.WriteLine("this is console output");
+            };
+        }
+    }
+
+    public static class describe_output_capture_output
+    {
+        public static string Output = @"
+describe output capture
+  output capture
+    should capture output
+      //Console output
+      this is console output
+
+1 Examples, 0 Failed, 0 Pending
+";
+    }
+}


### PR DESCRIPTION
With NspecRunner, writing to console in specs leads to console output not being printed in context

A spec like this:
```
 public class A_Sample_Spec :nspec
    {
        public void describe_a_behavior()
        {
            it["should do something"] = () =>
            {
                Console.WriteLine("some text");
                5.should_be(5);
            };
        }
   }
```

produces:
```
D:\code\NspecSample\NspecSample>..\packages\nspec.1.0.7\tools\NSpecRunner.exe bin\Debug\NspecSample.dll
some text

A Sample Spec
  describe a behavior
    should do something (9ms)
```

This PR captures stdout and stderr and saves the output in the example and prints it in context

```
D:\code\NspecSample\NspecSample>d:\code\NSpec\NSpecRunner\bin\Debug\NSpecRunner.exe bin\Debug\NspecSample.dll               
                                                                                                                            
A Sample Spec                                                                                                               
  describe a behavior                                                                                                       
    should do something (10ms)                                                                                              
      //Console output                                                                                                      
      some text                                                                                                             
    should do something else (0ms)                                                                                          
      //Console output                                                                                                      
      some else                                                                                                             
      a little bit more text                                                                                                
    a failing spec (2ms) - FAILED - Expected: 6, But was: 5                                                                 
      //Console output                                                                                                      
      some text before                                                                                                      
    a failing spec (0ms) - FAILED - something exceptional                                                                   
      //Console output                                                                                                      
      has some text before                                                                                                  
    handles multiline text output (2ms)                                                                                     
      //Console output                                                                                                      
      System.NullReferenceException: null!                                                                                  
         at NspecSample.A_Sample_Spec.bar() in D:\code\NspecSample\NspecSample\Class1.cs:line 77                            
         at NspecSample.A_Sample_Spec.foo() in D:\code\NspecSample\NspecSample\Class1.cs:line 72                            
         at NspecSample.A_Sample_Spec.<describe_a_behavior>b__0_4() in D:\code\NspecSample\NspecSample\Class1.cs:line 45    
    handles stderr as well (0ms)                                                                                            
      //Console output                                                                                                      
      a little text before                                                                                                  
      some error                                                                                                            
      after                                                                                                                 
  describe examples without output                                                                                          
    should not be affected (0ms)                                                                                            
    could be a pending spec - PENDING                                                                                       
                                                                                                                            
**** FAILURES ****                                                                                                          
                                                                                                                            
nspec. A Sample Spec. describe a behavior. a failing spec.                                                                  
Expected: 6, But was: 5                                                                                                     
   at NspecSample.A_Sample_Spec.<>c.<describe_a_behavior>b__0_2() in D:\code\NspecSample\NspecSample\Class1.cs:line 31      
                                                                                                                            
nspec. A Sample Spec. describe a behavior. a failing spec.                                                                  
something exceptional                                                                                                       
   at NspecSample.A_Sample_Spec.<>c.<describe_a_behavior>b__0_3() in D:\code\NspecSample\NspecSample\Class1.cs:line 38      
                                                                                                                            
8 Examples, 2 Failed, 1 Pending                                                                                             
```