### PR TITLE
fix(bareCode): avoid NullRef exception after spec c'tor throws

### DIFF
--- a/NSpec/Domain/ClassContext.cs
+++ b/NSpec/Domain/ClassContext.cs
@@ -30,6 +30,8 @@ namespace NSpec.Domain
             }
             catch (Exception ex)
             {
+                cantCreateInstance = true;
+
                 AddFailingExample(ex);
             }
         }
@@ -147,11 +149,24 @@ namespace NSpec.Domain
 
             var failingExample = new Example(exampleName, action: emptyAction)
             {
-                HasRun = true,
                 Exception = new ContextBareCodeException(reportedEx),
             };
 
             this.AddExample(failingExample);
+        }
+
+        public override void Run(Formatters.ILiveFormatter formatter, bool failFast, nspec instance = null)
+        {
+            if (cantCreateInstance)
+            {
+                // flag the one and only failing example as being run;
+                // nothing else is needed: no parents, no childs, no before/after hooks
+                Examples.Single().HasRun = true;
+            }
+            else
+            {
+                base.Run(formatter, failFast, instance);
+            }
         }
 
         public ClassContext(Type type, Conventions conventions = null, Tags tagsFilter = null, string tags = null)
@@ -174,5 +189,6 @@ namespace NSpec.Domain
         Tags tagsFilter;
         List<Type> classHierarchyToClass = new List<Type>();
         Conventions conventions;
+        bool cantCreateInstance = false;
     }
 }

--- a/NSpecSpecs/describe_Context.cs
+++ b/NSpecSpecs/describe_Context.cs
@@ -28,7 +28,7 @@ namespace NSpecSpecs
         {
             var child = new Context("child");
 
-            child.AddExample(new ExampleBaseWrap { Exception = new Exception() });
+            child.AddExample(new ExampleBaseWrap { Exception = new KnownException() });
 
             var parent = new Context("parent");
 

--- a/NSpecSpecs/describe_Context.cs
+++ b/NSpecSpecs/describe_Context.cs
@@ -38,27 +38,28 @@ namespace NSpecSpecs
         }
     }
 
-    public class child_act : parent_act
-    {
-        void act_each()
-        {
-            actResult += "child";
-        }
-    }
-
-    public class parent_act : nspec
-    {
-        public string actResult;
-        void act_each()
-        {
-            actResult = "parent";
-        }
-    }
-
     [TestFixture]
     [Category("Context")]
     public class when_creating_act_contexts_for_derived_class
     {
+        public class child_act : parent_act
+        {
+            void act_each()
+            {
+                actResult += "child";
+            }
+        }
+
+        public class parent_act : nspec
+        {
+            public string actResult;
+
+            void act_each()
+            {
+                actResult = "parent";
+            }
+        }
+
         [SetUp]
         public void setup()
         {
@@ -86,27 +87,28 @@ namespace NSpecSpecs
         child_act instance;
     }
 
-    public class child_before : parent_before
-    {
-        void before_each()
-        {
-            beforeResult += "child";
-        }
-    }
-
-    public class parent_before : nspec
-    {
-        public string beforeResult;
-        void before_each()
-        {
-            beforeResult = "parent";
-        }
-    }
-
     [TestFixture]
     [Category("Context")]
     public class when_creating_contexts_for_derived_classes
     {
+        public class child_before : parent_before
+        {
+            void before_each()
+            {
+                beforeResult += "child";
+            }
+        }
+
+        public class parent_before : nspec
+        {
+            public string beforeResult;
+
+            void before_each()
+            {
+                beforeResult = "parent";
+            }
+        }
+
         [SetUp]
         public void setup()
         {
@@ -144,6 +146,24 @@ namespace NSpecSpecs
     [Category("Context")]
     public class when_creating_before_contexts_for_derived_class
     {
+        public class child_before : parent_before
+        {
+            void before_each()
+            {
+                beforeResult += "child";
+            }
+        }
+
+        public class parent_before : nspec
+        {
+            public string beforeResult;
+
+            void before_each()
+            {
+                beforeResult = "parent";
+            }
+        }
+
         [SetUp]
         public void setup()
         {
@@ -171,7 +191,7 @@ namespace NSpecSpecs
         child_before instance;
     }
 
-    public class trimming_contexts
+    public abstract class trimming_contexts
     {
         protected Context rootContext;
 
@@ -297,7 +317,7 @@ namespace NSpecSpecs
     [Category("BareCode")]
     public class when_bare_code_throws_in_class_context
     {
-        public class SpecClass : nspec
+        public class CtorThrowsSpecClass : nspec
         {
             readonly object someTestObject = DoSomethingThatThrows();
 
@@ -319,14 +339,14 @@ namespace NSpecSpecs
 
             public static Exception SpecException;
 
-            public static string TypeFullName = typeof(SpecClass).FullName;
+            public static string TypeFullName = typeof(CtorThrowsSpecClass).FullName;
             public static string ExceptionTypeName = typeof(KnownException).Name;
         }
 
         [SetUp]
         public void setup()
         {
-            var specType = typeof(SpecClass);
+            var specType = typeof(CtorThrowsSpecClass);
 
             classContext = new ClassContext(specType);
 
@@ -350,7 +370,7 @@ namespace NSpecSpecs
 
             string actual = classContext.AllExamples().Single().FullName();
 
-            actual.should_contain(SpecClass.ExceptionTypeName);
+            actual.should_contain(CtorThrowsSpecClass.ExceptionTypeName);
         }
 
         ClassContext classContext;
@@ -361,7 +381,7 @@ namespace NSpecSpecs
     [Category("BareCode")]
     public class when_bare_code_throws_in_nested_context
     {
-        public class SpecClass : nspec
+        public class NestedContextThrowsSpecClass : nspec
         {
             public void method_level_context()
             {
@@ -386,7 +406,7 @@ namespace NSpecSpecs
         [SetUp]
         public void setup()
         {
-            var specType = typeof(SpecClass);
+            var specType = typeof(NestedContextThrowsSpecClass);
 
             classContext = new ClassContext(specType);
 
@@ -410,7 +430,7 @@ namespace NSpecSpecs
 
             string actual = classContext.AllExamples().Single().FullName();
 
-            actual.should_contain(SpecClass.ExceptionTypeName);
+            actual.should_contain(NestedContextThrowsSpecClass.ExceptionTypeName);
         }
 
         ClassContext classContext;

--- a/NSpecSpecs/describe_ContextCollection.cs
+++ b/NSpecSpecs/describe_ContextCollection.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using NSpec;
 using NSpec.Domain;
 using NUnit.Framework;
+using NSpecSpecs.describe_RunningSpecs.Exceptions;
 
 namespace NSpecSpecs
 {
@@ -23,7 +24,7 @@ namespace NSpecSpecs
 
             context.AddExample(new ExampleBaseWrap { Pending = true });
 
-            context.AddExample(new ExampleBaseWrap { Exception = new Exception() });
+            context.AddExample(new ExampleBaseWrap { Exception = new KnownException() });
 
             context.Tags.Add(Tags.Focus);
 

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_act_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_act_contains_exception.cs
@@ -10,7 +10,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("RunningSpecs")]
     public class when_act_contains_exception : when_running_specs
     {
-        private class SpecClass : nspec
+        private class ActThrowsSpecClass : nspec
         {
             void method_level_context()
             {
@@ -53,7 +53,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(ActThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_after_all_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_after_all_contains_exception.cs
@@ -10,7 +10,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("RunningSpecs")]
     public class when_after_all_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class AfterAllThrowsSpecClass : nspec
         {
             void method_level_context()
             {
@@ -53,7 +53,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(AfterAllThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_after_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_after_contains_exception.cs
@@ -10,7 +10,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("RunningSpecs")]
     public class when_after_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class AfterThrowsSpecClass : nspec
         {
             void method_level_context()
             {
@@ -53,7 +53,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(AfterThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_act_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_act_contains_exception.cs
@@ -12,7 +12,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("Async")]
     public class when_async_act_contains_exception : when_running_specs
     {
-        private class SpecClass : nspec
+        private class AsyncActThrowsSpecClass : nspec
         {
             void method_level_context()
             {
@@ -55,7 +55,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(AsyncActThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_after_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_after_contains_exception.cs
@@ -12,7 +12,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("Async")]
     public class when_async_after_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class AsyncAfterThrowsSpecClass : nspec
         {
             void method_level_context()
             {
@@ -59,7 +59,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(AsyncAfterThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_before_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_before_contains_exception.cs
@@ -12,7 +12,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("Async")]
     public class when_async_before_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class AsyncBeforeThrowsSpecClass : nspec
         {
             void method_level_context()
             {
@@ -59,7 +59,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(AsyncBeforeThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_method_level_before_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_async_method_level_before_contains_exception.cs
@@ -13,7 +13,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("Async")]
     public class when_async_method_level_before_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class AsyncMethodBeforeThrowsSpecClass : nspec
         {
             async Task before_each()
             {
@@ -31,7 +31,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(AsyncMethodBeforeThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_before_all_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_before_all_contains_exception.cs
@@ -10,7 +10,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("RunningSpecs")]
     public class when_before_all_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class BeforeAllThrowsSpecClass : nspec
         {
             void method_level_context()
             {
@@ -56,7 +56,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(BeforeAllThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_before_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_before_contains_exception.cs
@@ -10,7 +10,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("RunningSpecs")]
     public class when_before_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class BeforeThrowsSpecClass : nspec
         {
             void method_level_context()
             {
@@ -53,7 +53,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(BeforeThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_after_all_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_after_all_contains_exception.cs
@@ -11,7 +11,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("RunningSpecs")]
     public class when_method_level_after_all_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class MethodAfterAllThrowsSpecClass : nspec
         {
             void after_all()
             {
@@ -32,7 +32,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(MethodAfterAllThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_after_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_after_contains_exception.cs
@@ -11,7 +11,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("RunningSpecs")]
     public class when_method_level_after_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class MethodAfterThrowsSpecClass : nspec
         {
             void after_each()
             {
@@ -27,7 +27,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(MethodAfterThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_before_all_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_before_all_contains_exception.cs
@@ -11,7 +11,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("RunningSpecs")]
     public class when_method_level_before_all_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class MethodBeforeAllThrowsSpecClass : nspec
         {
             void before_all()
             {
@@ -32,7 +32,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(MethodBeforeAllThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_before_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_before_contains_exception.cs
@@ -11,7 +11,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("RunningSpecs")]
     public class when_method_level_before_contains_exception : when_running_specs
     {
-        class SpecClass : nspec
+        class MethodBeforeThrowsSpecClass : nspec
         {
             void before_each()
             {
@@ -27,7 +27,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(MethodBeforeThrowsSpecClass));
         }
 
         [Test]

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
@@ -12,7 +12,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("BareCode")]
     public class when_method_level_context_contains_exception : when_running_specs
     {
-        public class SpecClass : nspec
+        public class MethodContextThrowsSpecClass : nspec
         {
             public void method_level_context()
             {
@@ -40,7 +40,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(MethodContextThrowsSpecClass));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             var example = FindSyntheticExample();
 
-            example.Exception.InnerException.should_be(SpecClass.SpecException);
+            example.Exception.InnerException.should_be(MethodContextThrowsSpecClass.SpecException);
         }
 
         ExampleBase FindSyntheticExample()
@@ -72,7 +72,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             var filteredExamples =
                 from exm in AllExamples()
                 let fullname = exm.FullName()
-                where fullname.Contains(SpecClass.ExceptionTypeName)
+                where fullname.Contains(MethodContextThrowsSpecClass.ExceptionTypeName)
                 select exm;
 
             var example = filteredExamples.FirstOrDefault();

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_method_level_context_contains_exception.cs
@@ -14,7 +14,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     {
         public class MethodContextThrowsSpecClass : nspec
         {
-            public void method_level_context()
+            public void method_level_context_throwing()
             {
                 DoSomethingThatThrows();
 
@@ -46,15 +46,15 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [Test]
         public void synthetic_example_name_should_show_exception()
         {
-            var example = FindSyntheticExample();
+            var example = AllExamples().Single();
 
-            example.should_not_be_null();
+            example.FullName().should_contain(MethodContextThrowsSpecClass.ExceptionTypeName);
         }
 
         [Test]
         public void synthetic_example_should_fail_with_bare_code_exception()
         {
-            var example = FindSyntheticExample();
+            var example = AllExamples().Single();
 
             example.Exception.GetType().should_be(typeof(ContextBareCodeException));
         }
@@ -62,22 +62,9 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [Test]
         public void bare_code_exception_should_wrap_spec_exception()
         {
-            var example = FindSyntheticExample();
+            var example = AllExamples().Single();
 
             example.Exception.InnerException.should_be(MethodContextThrowsSpecClass.SpecException);
-        }
-
-        ExampleBase FindSyntheticExample()
-        {
-            var filteredExamples =
-                from exm in AllExamples()
-                let fullname = exm.FullName()
-                where fullname.Contains(MethodContextThrowsSpecClass.ExceptionTypeName)
-                select exm;
-
-            var example = filteredExamples.FirstOrDefault();
-
-            return example;
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_spec_class_ctor_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_spec_class_ctor_contains_exception.cs
@@ -47,15 +47,17 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [Test]
         public void synthetic_example_name_should_show_class_and_exception()
         {
-            var example = FindSyntheticExample();
+            var example = AllExamples().Single();
 
-            example.should_not_be_null();
+            example.FullName().should_contain(CtorThrowsSpecClass.TypeFullName);
+
+            example.FullName().should_contain(CtorThrowsSpecClass.ExceptionTypeName);
         }
 
         [Test]
         public void synthetic_example_should_fail_with_bare_code_exception()
         {
-            var example = FindSyntheticExample();
+            var example = AllExamples().Single();
 
             example.Exception.GetType().should_be(typeof(ContextBareCodeException));
         }
@@ -63,23 +65,9 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [Test]
         public void bare_code_exception_should_wrap_spec_exception()
         {
-            var example = FindSyntheticExample();
+            var example = AllExamples().Single();
 
             example.Exception.InnerException.should_be(CtorThrowsSpecClass.SpecException);
-        }
-
-        ExampleBase FindSyntheticExample()
-        {
-            var filteredExamples =
-                from exm in AllExamples()
-                let fullname = exm.FullName()
-                where fullname.Contains(CtorThrowsSpecClass.TypeFullName) &&
-                    fullname.Contains(CtorThrowsSpecClass.ExceptionTypeName)
-                select exm;
-
-            var example = filteredExamples.FirstOrDefault();
-
-            return example;
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_spec_class_ctor_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_spec_class_ctor_contains_exception.cs
@@ -12,7 +12,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("BareCode")]
     public class when_spec_class_ctor_contains_exception : when_running_specs
     {
-        public class SpecClass : nspec
+        public class CtorThrowsSpecClass : nspec
         {
             readonly object someTestObject = DoSomethingThatThrows();
 
@@ -34,14 +34,14 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
 
             public static Exception SpecException;
 
-            public static string TypeFullName = typeof(SpecClass).FullName;
+            public static string TypeFullName = typeof(CtorThrowsSpecClass).FullName;
             public static string ExceptionTypeName = typeof(KnownException).Name;
         }
 
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(CtorThrowsSpecClass));
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             var example = FindSyntheticExample();
 
-            example.Exception.InnerException.should_be(SpecClass.SpecException);
+            example.Exception.InnerException.should_be(CtorThrowsSpecClass.SpecException);
         }
 
         ExampleBase FindSyntheticExample()
@@ -73,8 +73,8 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             var filteredExamples =
                 from exm in AllExamples()
                 let fullname = exm.FullName()
-                where fullname.Contains(SpecClass.TypeFullName) &&
-                    fullname.Contains(SpecClass.ExceptionTypeName)
+                where fullname.Contains(CtorThrowsSpecClass.TypeFullName) &&
+                    fullname.Contains(CtorThrowsSpecClass.ExceptionTypeName)
                 select exm;
 
             var example = filteredExamples.FirstOrDefault();

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
@@ -12,7 +12,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
     [Category("BareCode")]
     public class when_sub_context_contains_exception : when_running_specs
     {
-        public class SpecClass : nspec
+        public class SubContextThrowsSpecClass : nspec
         {
             public void method_level_context()
             {
@@ -43,7 +43,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [SetUp]
         public void setup()
         {
-            Run(typeof(SpecClass));
+            Run(typeof(SubContextThrowsSpecClass));
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             var example = FindSyntheticExample();
 
-            example.Exception.InnerException.should_be(SpecClass.SpecException);
+            example.Exception.InnerException.should_be(SubContextThrowsSpecClass.SpecException);
         }
 
         ExampleBase FindSyntheticExample()
@@ -75,7 +75,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
             var filteredExamples =
                 from exm in AllExamples()
                 let fullname = exm.FullName()
-                where fullname.Contains(SpecClass.ExceptionTypeName)
+                where fullname.Contains(SubContextThrowsSpecClass.ExceptionTypeName)
                 select exm;
 
             var example = filteredExamples.FirstOrDefault();

--- a/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
+++ b/NSpecSpecs/describe_RunningSpecs/Exceptions/when_sub_context_contains_exception.cs
@@ -16,7 +16,7 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         {
             public void method_level_context()
             {
-                context["sub level context"] = () =>
+                context["sub level context throwing"] = () =>
                 {
                     DoSomethingThatThrows();
 
@@ -49,15 +49,15 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [Test]
         public void synthetic_example_name_should_show_exception()
         {
-            var example = FindSyntheticExample();
+            var example = AllExamples().Single();
 
-            example.should_not_be_null();
+            example.FullName().should_contain(SubContextThrowsSpecClass.ExceptionTypeName);
         }
 
         [Test]
         public void synthetic_example_should_fail_with_bare_code_exception()
         {
-            var example = FindSyntheticExample();
+            var example = AllExamples().Single();
 
             example.Exception.GetType().should_be(typeof(ContextBareCodeException));
         }
@@ -65,22 +65,9 @@ namespace NSpecSpecs.describe_RunningSpecs.Exceptions
         [Test]
         public void bare_code_exception_should_wrap_spec_exception()
         {
-            var example = FindSyntheticExample();
+            var example = AllExamples().Single();
 
             example.Exception.InnerException.should_be(SubContextThrowsSpecClass.SpecException);
-        }
-
-        ExampleBase FindSyntheticExample()
-        {
-            var filteredExamples =
-                from exm in AllExamples()
-                let fullname = exm.FullName()
-                where fullname.Contains(SubContextThrowsSpecClass.ExceptionTypeName)
-                select exm;
-
-            var example = filteredExamples.FirstOrDefault();
-
-            return example;
         }
     }
 }

--- a/NSpecSpecs/describe_RunningSpecs/describe_example.cs
+++ b/NSpecSpecs/describe_RunningSpecs/describe_example.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NSpec;
 using NUnit.Framework;
+using NSpecSpecs.describe_RunningSpecs.Exceptions;
 
 namespace NSpecSpecs.WhenRunningSpecs
 {
@@ -20,7 +21,7 @@ namespace NSpecSpecs.WhenRunningSpecs
 
             void it_fails()
             {
-                throw new Exception();
+                throw new KnownException();
             }
         }
 

--- a/NSpecSpecs/describe_RunningSpecs/describe_todo.cs
+++ b/NSpecSpecs/describe_RunningSpecs/describe_todo.cs
@@ -4,6 +4,7 @@ using NSpec;
 using NSpec.Domain;
 using NUnit.Framework;
 using System.Threading.Tasks;
+using NSpecSpecs.describe_RunningSpecs.Exceptions;
 
 namespace NSpecSpecs.WhenRunningSpecs
 {
@@ -213,7 +214,7 @@ namespace NSpecSpecs.WhenRunningSpecs
         {
             void method_level_context()
             {
-                before = () => { throw new Exception(); };
+                before = () => { throw new KnownException(); };
 
                 it["should be pending"] = todo;
             }

--- a/NSpecSpecs/describe_RunningSpecs/describe_xcontext.cs
+++ b/NSpecSpecs/describe_RunningSpecs/describe_xcontext.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using NSpec;
 using NUnit.Framework;
+using NSpecSpecs.describe_RunningSpecs.Exceptions;
 
 namespace NSpecSpecs.WhenRunningSpecs
 {
@@ -43,8 +44,8 @@ namespace NSpecSpecs.WhenRunningSpecs
         class SpecClass : nspec
         {
             public static string output = string.Empty;
-            public static Action MethodLevelBefore = () => { throw new Exception("this should not run."); };
-            public static Action SubContextBefore = () => { throw new Exception("this should not run."); };
+            public static Action MethodLevelBefore = () => { throw new KnownException("this should not run."); };
+            public static Action SubContextBefore = () => { throw new KnownException("this should not run."); };
 
             void method_level_context()
             {


### PR DESCRIPTION
Main commit to double check is [58072e2](https://github.com/mattflo/NSpec/commit/58072e2c222c96e82b4e07e12596b1f0de60c530), "fix(bareCode): avoid NullRef exception after spec c'tor throws".

When, for some reason (bare code throwing), a spec class constructor fails the context is left in an uncomplete state (`savedinstance` is null) and so trying to run normally causes null reference exception. Given that the whole spec class cannot be constructed, there's no point in trying to run any hook, or nested context, or else. Just the synthetic failing example.